### PR TITLE
Config commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,12 @@
     "@geut/seeder": "^0.0.1",
     "@oclif/command": "^1.7.0",
     "@oclif/config": "^1.16.0",
-    "@oclif/plugin-help": "^3.1.0"
+    "@oclif/errors": "^1.3.3",
+    "@oclif/plugin-help": "^3.1.0",
+    "deep-extend": "^0.6.0",
+    "lodash.get": "^4.4.2",
+    "lodash.set": "^4.3.2",
+    "@iarna/toml": "^2.2.5"
   },
   "devDependencies": {
     "@geut/chan": "^2.2.1",

--- a/packages/cli/src/base-command.js
+++ b/packages/cli/src/base-command.js
@@ -1,0 +1,17 @@
+const { Command, flags } = require('@oclif/command')
+
+class BaseCommand extends Command {
+  log (msg, force = false) {
+    const { flags } = this.parse(this.constructor)
+
+    if (flags.verbose || force) {
+      return super.log(msg)
+    }
+  }
+}
+
+BaseCommand.flags = {
+  verbose: flags.boolean({ description: 'Log output', default: false })
+}
+
+module.exports = BaseCommand

--- a/packages/cli/src/commands/config/get.js
+++ b/packages/cli/src/commands/config/get.js
@@ -1,0 +1,36 @@
+const config = require('../../config')
+const BaseCommand = require('../../base-command')
+
+const ConfigCommand = require('.')
+
+class GetCommand extends ConfigCommand {
+  async run () {
+    const { args: { key } } = this.parse(GetCommand)
+
+    const configValues = await config.get(key, {
+      globalConfigFolderPath: this.globalConfigFolderPath,
+      localConfigFolderPath: this.localConfigFolderPath
+    })
+
+    if (key && configValues === undefined) {
+      return this.warn(`No config key found: ${key}`)
+    } else if (configValues === undefined) {
+      return this.warn('No config file found')
+    }
+
+    this.log(JSON.stringify(configValues, null, 2), true)
+  }
+}
+
+GetCommand.description = 'Shows a config entry based on key'
+
+GetCommand.args = [
+  { name: 'key', description: 'Config key to show\nIf not present shows all config entries' }
+]
+
+GetCommand.flags = {
+  ...ConfigCommand.flags,
+  ...BaseCommand.flags
+}
+
+module.exports = GetCommand

--- a/packages/cli/src/commands/config/index.js
+++ b/packages/cli/src/commands/config/index.js
@@ -1,0 +1,28 @@
+const path = require('path')
+const { flags } = require('@oclif/command')
+
+const BaseCommand = require('../../base-command')
+
+class ConfigCommand extends BaseCommand {
+  async run () {
+    this._help()
+  }
+
+  get localConfigFolderPath () {
+    return path.resolve(__dirname)
+  }
+
+  get globalConfigFolderPath () {
+    return this.config.home
+  }
+}
+
+ConfigCommand.usage = ['config:[init|list|set|get]']
+
+ConfigCommand.description = 'Configuration commands'
+
+ConfigCommand.flags = {
+  global: flags.boolean({ char: 'g', description: 'Use global config', default: false })
+}
+
+module.exports = ConfigCommand

--- a/packages/cli/src/commands/config/index.js
+++ b/packages/cli/src/commands/config/index.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const { resolve } = require('path')
 const { flags } = require('@oclif/command')
 
 const BaseCommand = require('../../base-command')
@@ -9,7 +9,7 @@ class ConfigCommand extends BaseCommand {
   }
 
   get localConfigFolderPath () {
-    return path.resolve(__dirname)
+    return resolve(__dirname)
   }
 
   get globalConfigFolderPath () {

--- a/packages/cli/src/commands/config/init.js
+++ b/packages/cli/src/commands/config/init.js
@@ -1,0 +1,33 @@
+const { flags } = require('@oclif/command')
+
+const config = require('../../config')
+const BaseCommand = require('../../base-command')
+
+const ConfigCommand = require('.')
+
+class InitCommand extends ConfigCommand {
+  async run () {
+    const { flags: { global, force } } = this.parse(InitCommand)
+    const configFolderPath = global ? this.globalConfigFolderPath : this.localConfigFolderPath
+
+    await config.init(configFolderPath, { force })
+  }
+
+  async catch (error) {
+    if (error.code === 'EEXIST') {
+      this.error(`Config file ${error.dest} already exists.`, { suggestions: ['Use --force to override.'] })
+    } else {
+      throw error
+    }
+  }
+}
+
+InitCommand.description = 'Creates a default config file'
+
+InitCommand.flags = {
+  force: flags.boolean({ char: 'f', description: 'Force', default: false }),
+  ...ConfigCommand.flags,
+  ...BaseCommand.flags
+}
+
+module.exports = InitCommand

--- a/packages/cli/src/commands/config/set.js
+++ b/packages/cli/src/commands/config/set.js
@@ -1,0 +1,49 @@
+const config = require('../../config')
+const BaseCommand = require('../../base-command')
+
+const ConfigCommand = require('.')
+
+class SetCommand extends ConfigCommand {
+  async run () {
+    const { args: { key, value }, flags: { global } } = this.parse(SetCommand)
+    const configFolderPath = global ? this.globalConfigFolderPath : this.localConfigFolderPath
+
+    await config.set(key, value, { configFolderPath })
+  }
+
+  async catch (error) {
+    if (error.code === 'CONFIG_FILE_NOT_EXISTS') {
+      this.error(error.message, { suggestions: ['Use config:init command to create a default one.'] })
+    } else {
+      throw error
+    }
+  }
+}
+
+SetCommand.description = 'Sets a config value based on key'
+
+SetCommand.args = [
+  { name: 'key', required: true, description: 'Config key to set' },
+  {
+    name: 'value',
+    required: true,
+    description: 'Config value to set on key entry',
+    parse: input => {
+      try {
+        const boolOrNumber = JSON.parse(input)
+        if (['boolean', 'number'].includes(typeof boolOrNumber)) {
+          return boolOrNumber
+        }
+      } catch {}
+
+      return input
+    }
+  }
+]
+
+SetCommand.flags = {
+  ...ConfigCommand.flags,
+  ...BaseCommand.flags
+}
+
+module.exports = SetCommand

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -1,18 +1,19 @@
 const { promises: { copyFile, writeFile }, constants: { COPYFILE_EXCL }, createReadStream } = require('fs')
-const path = require('path')
+const { join, resolve } = require('path')
 const lodashGet = require('lodash.get')
 const lodashSet = require('lodash.set')
 const deepExtend = require('deep-extend')
-const toml = require('@iarna/toml')
+const tomlParseStream = require('@iarna/toml/parse-stream')
+const tomlStringify = require('@iarna/toml/stringify')
 
 const CONFIG_FILENAME = 'permanent-seeder.toml'
 const CONFIG_EXAMPLE_FILENAME = 'permanent-seeder.example.toml'
 
 const getConfig = async folderPath => {
-  const filePath = path.resolve(path.join(folderPath, CONFIG_FILENAME))
+  const filePath = resolve(join(folderPath, CONFIG_FILENAME))
   let config
   try {
-    config = await toml.parse.stream(createReadStream(filePath, { encoding: 'utf-8' }))
+    config = await tomlParseStream(createReadStream(filePath, { encoding: 'utf-8' }))
   } catch (error) {}
 
   return config
@@ -26,10 +27,10 @@ const getConfig = async folderPath => {
  * @param {boolean} options.force Override existent file
  */
 module.exports.init = async (configFolderPath, options = {}) => {
-  const filePath = path.resolve(path.join(configFolderPath, CONFIG_FILENAME))
+  const filePath = resolve(join(configFolderPath, CONFIG_FILENAME))
 
   await copyFile(
-    path.resolve(__dirname, CONFIG_EXAMPLE_FILENAME),
+    resolve(__dirname, CONFIG_EXAMPLE_FILENAME),
     filePath,
     options.force ? null : COPYFILE_EXCL
   )
@@ -77,7 +78,7 @@ module.exports.set = async (key, value, options = {}) => {
 
   lodashSet(config, key, value)
 
-  const filePath = path.resolve(path.join(options.configFolderPath, CONFIG_FILENAME))
+  const filePath = resolve(join(options.configFolderPath, CONFIG_FILENAME))
 
-  await writeFile(filePath, toml.stringify(config), 'utf-8')
+  await writeFile(filePath, tomlStringify(config), 'utf-8')
 }

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -1,0 +1,83 @@
+const { promises: { copyFile, writeFile }, constants: { COPYFILE_EXCL }, createReadStream } = require('fs')
+const path = require('path')
+const lodashGet = require('lodash.get')
+const lodashSet = require('lodash.set')
+const deepExtend = require('deep-extend')
+const toml = require('@iarna/toml')
+
+const CONFIG_FILENAME = 'permanent-seeder.toml'
+const CONFIG_EXAMPLE_FILENAME = 'permanent-seeder.example.toml'
+
+const getConfig = async folderPath => {
+  const filePath = path.resolve(path.join(folderPath, CONFIG_FILENAME))
+  let config
+  try {
+    config = await toml.parse.stream(createReadStream(filePath, { encoding: 'utf-8' }))
+  } catch (error) {}
+
+  return config
+}
+
+/**
+ * Creates a config file on the specified location
+ *
+ * @param {string} configFolderPath Path to the folder where config file will be created
+ * @param {object} options Options
+ * @param {boolean} options.force Override existent file
+ */
+module.exports.init = async (configFolderPath, options = {}) => {
+  const filePath = path.resolve(path.join(configFolderPath, CONFIG_FILENAME))
+
+  await copyFile(
+    path.resolve(__dirname, CONFIG_EXAMPLE_FILENAME),
+    filePath,
+    options.force ? null : COPYFILE_EXCL
+  )
+}
+
+/**
+ * Returns a config entry based on key.
+ * If key not present return all config entries
+ *
+ * @param {string} key Config key
+ * @param {object} options Options
+ * @param {string} options.globalConfigFolderPath Path to the folder where config file resides (global)
+ * @param {string} options.localConfigFolderPath Path to the folder where config file resides (local)
+ */
+module.exports.get = async (key, options = {}) => {
+  const globalConfig = await getConfig(options.globalConfigFolderPath)
+  const localConfig = await getConfig(options.localConfigFolderPath)
+
+  if (!globalConfig && !localConfig) return
+
+  const mergedConfig = deepExtend(globalConfig, localConfig)
+
+  if (key) {
+    return lodashGet(mergedConfig, key)
+  }
+
+  return mergedConfig
+}
+
+/**
+ * Sets a config key => value
+ *
+ * @param {string} key Config key
+ * @param {any} value Value to set
+ * @param {string} options.configFolderPath Path to the folder where config file resides
+ */
+module.exports.set = async (key, value, options = {}) => {
+  const config = await getConfig(options.configFolderPath)
+
+  if (!config) {
+    const error = new Error(`Config file on ${options.configFolderPath} doesn't exists`)
+    error.code = 'CONFIG_FILE_NOT_EXISTS'
+    throw error
+  }
+
+  lodashSet(config, key, value)
+
+  const filePath = path.resolve(path.join(options.configFolderPath, CONFIG_FILENAME))
+
+  await writeFile(filePath, toml.stringify(config), 'utf-8')
+}

--- a/packages/cli/src/permanent-seeder.example.toml
+++ b/packages/cli/src/permanent-seeder.example.toml
@@ -1,0 +1,6 @@
+[security]
+secret = 'YOUR_SECRET_HERE'
+
+[vault]
+endpoint_url = 'http://localhost:1234'
+key_fetch_frequency = 5 # Minutes


### PR DESCRIPTION
This PR adds a `config` command for handling `TOML` settings file.
- `config:get`: Get config (or a single key in config)
- `config:init`: Create a default config
- `config:set`: Set a config value

All with a `--global` optional flag. 

Closes: #5 