### PR TITLE
Add: metrics service

### DIFF
--- a/packages/database/index.js
+++ b/packages/database/index.js
@@ -1,5 +1,7 @@
 const Database = require('./src/database')
 const KeysDatabase = require('./src/keys-database')
+const MetricsDatabase = require('./src/metrics-database')
 
 module.exports.Database = Database
 module.exports.KeysDatabase = KeysDatabase
+module.exports.MetricsDatabase = MetricsDatabase

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -38,7 +38,9 @@
     "level-party": "^4.0.0",
     "levelup": "^4.4.0",
     "memdown": "^5.1.0",
-    "uuid": "^8.2.0"
+    "uuid": "^8.2.0",
+    "level-auto-index": "^2.0.0",
+    "subleveldown": "^5.0.1"
   },
   "devDependencies": {
     "@geut/chan": "^2.2.1",

--- a/packages/database/src/metrics-database.js
+++ b/packages/database/src/metrics-database.js
@@ -1,0 +1,62 @@
+const assert = require('assert')
+const Database = require('./database')
+
+class MetricsDatabase extends Database {
+  _buildKey (keyParts) {
+    return ['metrics', ...keyParts].join('!')
+  }
+
+  _cleanKeyData (data = {}) {
+    assert(Buffer.isBuffer(data.key) || typeof data.key === 'string', 'key should be string or buffer')
+    const key = typeof data.key === 'string' ? data.key : data.key.toString('hex')
+
+    return {
+      key,
+      ...data
+    }
+  }
+
+  onPreSet (key, data) {
+    return this._cleanKeyData(data)
+  }
+
+  /**
+   *
+   * @param {object} data keyRecord to add
+   * @param {boolean} updateIfExists update keyRecord if exists
+   *
+   * @returns {boolean} true if existent and key was updated
+   */
+  async add (data, updateIfExists = false) {
+    const existent = await this.get(data.key, data.timestamp)
+
+    if (existent && !updateIfExists) {
+      throw new Error('Key already exists')
+    }
+
+    await this.set(data.key, data.timestamp, data)
+
+    return !!existent
+  }
+
+  /**
+   *
+   * @param {object} data keyRecord to update
+   * @param {boolean} createIfNotExists create keyRecord if not exists
+   *
+   * @returns {boolean} true if not existent and key was created
+   */
+  async update (data, createIfNotExists = false) {
+    const existent = await this.get(data.key, data.timestamp)
+
+    if (!existent && !createIfNotExists) {
+      throw new Error('Key not created')
+    }
+
+    await this.set(data.key, data.timestamp, data)
+
+    return !existent
+  }
+}
+
+module.exports = MetricsDatabase

--- a/packages/database/tests/metrics-database.test.js
+++ b/packages/database/tests/metrics-database.test.js
@@ -151,23 +151,18 @@ test('filter keys', async () => {
   const firstBatchKey = keys[0].key
 
   // add one extra key
-  const data = createRandomKeyData()
-  data.key = randomBytes(32).toString('hex')
+  const data = keys[0]
+  data.timestamp = Date.now()
   const dataKey = [data.key, data.timestamp]
   await metricsDB.set(...dataKey, data)
   const keys2 = await metricsDB.getAll()
   expect(keys2.length).toBe(11)
 
   // filter by key
-  // const gte = `metrics!${firstBatchKey}!`
-  const gte = metricsDB._buildKey([firstBatchKey, ''])
+  const keysFiltered = await metricsDB.filterByTimestamp(firstBatchKey)
+  expect(keysFiltered.length).toBe(2)
 
-  console.log({ gte })
-
-  const filter = {
-    lte: `${gte}~`
-  }
-  const keysFiltered = metricsDB._filter(filter)
-  // expect(metricsDB.getAll(firstBatchKey)).resolves.toHaveLength(10)
-  expect(keysFiltered.length).toBe(10)
+  // filter by key and timestamp`
+  const keysFilteredTimestamp = await metricsDB.filterByTimestamp(firstBatchKey, data.timestamp)
+  expect(keysFilteredTimestamp.length).toBe(1)
 })

--- a/packages/database/tests/metrics-database.test.js
+++ b/packages/database/tests/metrics-database.test.js
@@ -1,0 +1,173 @@
+const { randomBytes } = require('crypto')
+
+const memdown = require('memdown')
+const levelup = require('levelup')
+
+const MetricsDatabase = require('../src/metrics-database')
+
+let metricsDB
+
+const createRandomKeyData = () => {
+  const key = randomBytes(32).toString('hex')
+
+  return {
+    key,
+    timestamp: Date.now(),
+    drive: {
+      size: 1024,
+      atime: '2017-04-10T18:59:00.147Z',
+      mtime: '2017-04-10T18:59:00.147Z',
+      ctime: '2017-04-10T18:59:00.147Z'
+    },
+    content: {
+      key,
+      discoveryKey: {},
+      peerCount: 1,
+      peers: [
+        {
+          uploadedBytes: 512,
+          uploadedBlocks: 2,
+          downloadedBytes: 0,
+          downloadedBlocks: 0,
+          remoteAddress: '::ffff:192.168.0.223'
+        }
+      ],
+      uploadedBytes: 256,
+      uploadedBlocks: 2,
+      downloadedBytes: 0,
+      downloadedBlocks: 10,
+      totalBlocks: 10
+    },
+    metadata: {
+      key,
+      discoveryKey: {},
+      peerCount: 1,
+      peers: [
+        {
+          uploadedBytes: 101,
+          uploadedBlocks: 2,
+          downloadedBytes: 0,
+          downloadedBlocks: 0,
+          remoteAddress: '::ffff:192.168.0.223'
+        }
+      ],
+      uploadedBytes: 101,
+      uploadedBlocks: 2,
+      downloadedBytes: 0,
+      downloadedBlocks: 5,
+      totalBlocks: 5
+    },
+    network: {
+      announce: true,
+      lookup: false
+    }
+  }
+}
+
+beforeEach(() => {
+  metricsDB = new MetricsDatabase(memdown())
+})
+
+test('db created', () => {
+  expect(metricsDB._db).toBeTruthy()
+  expect(metricsDB._db).toBeInstanceOf(levelup)
+})
+
+test('clean/validate key', () => {
+  // TBD
+})
+
+test('get/add key', async () => {
+  const data = createRandomKeyData()
+
+  await metricsDB.add(data)
+
+  expect(metricsDB.add(data)).rejects.toBeTruthy()
+
+  data.title = 'updated-key'
+  await metricsDB.add(data, true)
+
+  const dataKey = [data.key.toString('hex'), data.timestamp]
+  const createdKey = await metricsDB.get(...dataKey)
+  expect(createdKey).toMatchObject(data)
+})
+
+test('get all keys', async () => {
+  // eslint-disable-next-line no-unused-vars
+  for (const _ of Array.from({ length: 10 })) {
+    const data = createRandomKeyData()
+    // key = (driveKey|timestamp)
+    const dataKey = [data.key, data.timestamp]
+    await metricsDB.set(...dataKey, data)
+  }
+
+  const keys = await metricsDB.getAll()
+
+  expect(keys.length).toBe(10)
+})
+
+test('update key', async () => {
+  const data = createRandomKeyData()
+
+  const dataKey = [data.key, data.timestamp]
+  await metricsDB.add(data)
+  const createdKey = await metricsDB.get(...dataKey)
+
+  createdKey.drive.size = 2048
+
+  await metricsDB.update(createdKey)
+  const updatedKey = await metricsDB.get(...dataKey)
+
+  const notExistentKey = createRandomKeyData()
+  expect(metricsDB.update(notExistentKey)).rejects.toBeTruthy()
+
+  expect(createdKey).toMatchObject(updatedKey)
+})
+
+test('remove key', async () => {
+  const data = createRandomKeyData()
+
+  await metricsDB.add(data)
+
+  const dataKey = [data.key, data.timestamp]
+  await metricsDB.remove(...dataKey)
+  await metricsDB.remove('not-present')
+
+  const removedKey = await metricsDB.get(...dataKey)
+
+  expect(removedKey).toBe(null)
+})
+
+test('filter keys', async () => {
+  // eslint-disable-next-line no-unused-vars
+  for (const _ of Array.from({ length: 10 })) {
+    const data = createRandomKeyData()
+    const dataKey = [data.key, data.timestamp]
+    await metricsDB.set(...dataKey, data)
+  }
+
+  const keys = await metricsDB.getAll()
+  expect(keys.length).toBe(10)
+  const firstBatchKey = keys[0].key
+
+  // add one extra key
+  const data = createRandomKeyData()
+  data.key = randomBytes(32).toString('hex')
+  const dataKey = [data.key, data.timestamp]
+  await metricsDB.set(...dataKey, data)
+  const keys2 = await metricsDB.getAll()
+  expect(keys2.length).toBe(11)
+
+  // filter by key
+  // const gte = `metrics!${firstBatchKey}!`
+  const gte = metricsDB._buildKey([firstBatchKey, ''])
+
+  console.log({ gte })
+
+  const filter = {
+    lte: `${gte}~`
+  }
+  const keysFiltered = metricsDB._filter(filter)
+  // expect(metricsDB.getAll(firstBatchKey)).resolves.toHaveLength(10)
+  expect(keysFiltered.length).toBe(10)
+})

--- a/packages/sdk/src/services/api.service.js
+++ b/packages/sdk/src/services/api.service.js
@@ -3,8 +3,7 @@ const path = require('path')
 const ApiGatewayService = require('moleculer-web')
 const IO = require('socket.io')
 
-const EXAMPLE_KEY = 'faa6f1af5e60c4edbc260ea473c0216dc7b5e79ee387922293313c3cdaa1da33'
-const EXAMPLE_KEY_1 = '7c9dff14680d00c791e33c9a7698ba4f98ef89bb06c3151d479fe6b050f0cdb3'
+/*
 const exampleDrive = key => ({
   key,
   title: 'A title for this key',
@@ -31,6 +30,7 @@ const exampleDrive = key => ({
   memory: Math.random(),
   disk: Math.random()
 })
+*/
 
 module.exports = {
   name: 'api',
@@ -73,17 +73,15 @@ module.exports = {
 
   actions: {
     drives: {
-      async handler () {
-        return {
-          [EXAMPLE_KEY]: exampleDrive(EXAMPLE_KEY),
-          [EXAMPLE_KEY_1]: exampleDrive(EXAMPLE_KEY_1)
-        }
+      async handler (ctx) {
+        const all = await ctx.call('metrics.getAll')
+        return all
       }
     },
 
     drive: {
       async handler (ctx) {
-        return exampleDrive(ctx.params.key)
+        return ctx.call('metrics.get', { key: ctx.params.key, timestamp: ctx.params.timestamp })
       }
     }
   },
@@ -95,8 +93,8 @@ module.exports = {
     // })
 
     // Drive updates
-    setInterval(() => this.broker.emit(`stats.drives.${EXAMPLE_KEY}`, exampleDrive(EXAMPLE_KEY)), 1000)
-    setInterval(() => this.broker.emit(`stats.drives.${EXAMPLE_KEY_1}`, exampleDrive(EXAMPLE_KEY_1)), 4200)
+    // setInterval(() => this.broker.emit(`stats.drives.${EXAMPLE_KEY}`, exampleDrive(EXAMPLE_KEY)), 1000)
+    // setInterval(() => this.broker.emit(`stats.drives.${EXAMPLE_KEY_1}`, exampleDrive(EXAMPLE_KEY_1)), 4200)
 
     // Create a Socket.IO instance, passing it our server
     this.io = IO.listen(this.server)

--- a/packages/sdk/src/services/metrics.service.js
+++ b/packages/sdk/src/services/metrics.service.js
@@ -10,11 +10,32 @@ module.exports = {
     'metricsdb'
   ],
 
+  events: {
+    'seeder.stats': {
+      async handler (ctx) {
+        await this.database.add(ctx.params)
+      }
+    }
+  },
+
   actions: {
+    get: {
+      params: {
+        key: { type: 'string', length: '64', hex: true },
+        timestamp: { type: 'number', optional: true }
+      },
+      async handler (ctx) {
+        return this.database.filterByTimestamp(ctx.params.key)
+      }
+    },
+    getAll: {
+      async handler () {
+        return this.database.getAll()
+      }
+    }
   },
 
   methods: {
-
   },
 
   created () {
@@ -23,9 +44,6 @@ module.exports = {
     }
 
     this.database = new MetricsDatabase(this.config.path)
-  },
-
-  async started () {
   },
 
   async stopped () {

--- a/packages/sdk/src/services/metrics.service.js
+++ b/packages/sdk/src/services/metrics.service.js
@@ -1,0 +1,35 @@
+const { Config } = require('../mixins/config.mixin')
+const { MetricsDatabase } = require('@geut/permanent-seeder-database')
+
+module.exports = {
+  name: 'metrics',
+
+  mixins: [Config],
+
+  dependencies: [
+    'metricsdb'
+  ],
+
+  actions: {
+  },
+
+  methods: {
+
+  },
+
+  created () {
+    this.config = {
+      ...this.seetings.config.metrics.db
+    }
+
+    this.database = new MetricsDatabase(this.config.path)
+  },
+
+  async started () {
+  },
+
+  async stopped () {
+    await this.database.close()
+  }
+
+}

--- a/packages/sdk/src/services/metrics.service.js
+++ b/packages/sdk/src/services/metrics.service.js
@@ -25,7 +25,7 @@ module.exports = {
         timestamp: { type: 'number', optional: true }
       },
       async handler (ctx) {
-        return this.database.filterByTimestamp(ctx.params.key)
+        return this.database.filterByTimestamp(ctx.params.key, ctx.params.timestamp)
       }
     },
     getAll: {

--- a/packages/sdk/src/services/seeder.service.js
+++ b/packages/sdk/src/services/seeder.service.js
@@ -75,12 +75,14 @@ module.exports = {
     // hook seeder events
     this.seeder.on('drive-download', async (key) => {
       const stat = await this.seeder.stat(key)
-      this.broker.broadcast('seeder.stats', { key, stat })
+      const timestamp = Date.now()
+      this.broker.broadcast('seeder.stats', { key, timestamp, stat })
     })
 
     this.seeder.on('drive-upload', async (key) => {
       const stat = await this.seeder.stat(key)
-      this.broker.broadcast('seeder.stats', { key, stat })
+      const timestamp = Date.now()
+      this.broker.broadcast('seeder.stats', { key, timestamp, stat })
     })
 
     await this.seed(keys.map(({ key }) => key))


### PR DESCRIPTION
new service: metrics

This service listen for `seeder.stats` events and save stats in its own db.

It also provides actions for query the stats by key and timestamp.