### PR TITLE
Update: drive stats

### DIFF
--- a/packages/sdk/src/services/seeder.service.js
+++ b/packages/sdk/src/services/seeder.service.js
@@ -45,6 +45,16 @@ module.exports = {
       }
     },
 
+    getDriveStats: {
+      params: {
+        key: { type: 'string' },
+        path: { type: 'string', optional: true }
+      },
+      async handler (ctx) {
+        return await this.seeder.getDriveStats(ctx.params.key, ctx.params.path)
+      }
+    },
+
     readdir: {
       params: {
         key: { type: 'string' },

--- a/packages/seeder/src/seeder.js
+++ b/packages/seeder/src/seeder.js
@@ -82,8 +82,16 @@ class Seeder extends EventEmitter {
    *
    * @param {} dkey
    */
-  get (dkey) {
-    return this.drives.get(dkey)
+  get (key) {
+    return this.drives.get(key)
+  }
+
+  getDriveStats (key, path = '/') {
+    const drive = this.drives.get(key)
+    if (!drive) {
+      return {}
+    }
+    return drive.stat(path)
   }
 
   /**

--- a/packages/seeder/src/seeder.js
+++ b/packages/seeder/src/seeder.js
@@ -165,11 +165,13 @@ class Seeder extends EventEmitter {
     */
     const getContentFeed = promisify(drive.getContent)
     const contentFeed = await getContentFeed()
+    const driveStat = await drive.stat('/')
 
     const stat = {
       content: await getCoreStats(contentFeed),
       metadata: await getCoreStats(drive.metadata),
-      network
+      network,
+      drive: driveStat
     }
 
     return stat


### PR DESCRIPTION
This PR adds a new method, `getDriveStats` both on seeder core and service. This can be used to access `drive.stat` inner method, useful to get stats using a path. 