### PR TITLE
Update: demo vault endpoint

### DIFF
--- a/packages/cli/demo/modules.json
+++ b/packages/cli/demo/modules.json
@@ -1,0 +1,10 @@
+{
+  "data": [
+    {
+      "id":1,
+      "created_at":"2020-08-04T12:29:40.129Z",
+      "url":"hyper://7618eb410822affa2e24b55d35469db7f74619e78ff1bf34b7049a596741a5b3",
+      "title": "demo module"
+    }
+  ]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
     "/src"
   ],
   "scripts": {
+    "demo": "npx http-server ./demo -p 8383",
     "lint": "xd-ns \"**/*.js\"",
     "prepack": "oclif-dev manifest && oclif-dev readme",
     "postpack": "rm -f oclif.manifest.json",

--- a/packages/sdk/src/services/keys-updater.service.js
+++ b/packages/sdk/src/services/keys-updater.service.js
@@ -45,7 +45,8 @@ module.exports = {
       async handler () {
         const keys = await this.fetchKeys()
 
-        this.updateKeys(keys)
+        // Note(dk): this might need an update when we consume the real endpoint
+        this.updateKeys(keys.data)
       }
     }
   },
@@ -62,7 +63,7 @@ module.exports = {
     },
 
     async updateKeys (keys) {
-      await this.ctx.call('keys.updateAll', { keys })
+      await this.broker.call('keys.updateAll', { keys })
     }
   },
 

--- a/packages/sdk/src/services/keys.service.js
+++ b/packages/sdk/src/services/keys.service.js
@@ -1,5 +1,6 @@
 const Cron = require('moleculer-cron')
 const deepEqual = require('deep-equal')
+const { encode } = require('dat-encoding')
 
 const { KeysDatabase } = require('@geut/permanent-seeder-database')
 
@@ -31,14 +32,23 @@ module.exports = {
           items: {
             type: 'object',
             props: {
-              key: { type: 'string', length: '64', hex: true },
-              title: { type: 'string', empty: 'false' }
+              url: { type: 'string' },
+              title: { type: 'string', empty: 'false' },
+              id: { type: 'number' },
+              created_at: { type: 'string' }
             }
           }
         }
       },
       async handler (ctx) {
-        await this.updateKeys(ctx.params.keys)
+        this.logger.info(ctx.params.keys)
+        const keys = ctx.params.keys.map(datum => {
+          const key = encode(datum.url)
+          delete datum.url
+
+          return { ...datum, key }
+        })
+        await this.updateKeys(keys)
       }
     },
 

--- a/packages/sdk/src/services/seeder.service.js
+++ b/packages/sdk/src/services/seeder.service.js
@@ -114,7 +114,7 @@ module.exports = {
       const timestamp = Date.now()
       this.broker.broadcast('seeder.stats', { key, timestamp, stat })
     })
-    
+
     this.seeder.on('drive-sync', async (key) => {
       const stat = await this.seeder.stat(key)
       const timestamp = Date.now()

--- a/packages/sdk/src/services/seeder.service.js
+++ b/packages/sdk/src/services/seeder.service.js
@@ -101,6 +101,18 @@ module.exports = {
       this.broker.broadcast('seeder.stats', { key, timestamp, stat })
     })
 
+    this.seeder.on('drive-peer-add', async (key) => {
+      const stat = await this.seeder.stat(key)
+      const timestamp = Date.now()
+      this.broker.broadcast('seeder.stats', { key, timestamp, stat })
+    })
+
+    this.seeder.on('drive-peer-remove', async (key) => {
+      const stat = await this.seeder.stat(key)
+      const timestamp = Date.now()
+      this.broker.broadcast('seeder.stats', { key, timestamp, stat })
+    })
+
     await this.seed(keys.map(({ key }) => key))
   },
 
@@ -109,6 +121,8 @@ module.exports = {
     this.seeder.removeAllListeners('drive-new')
     this.seeder.removeAllListeners('drive-download')
     this.seeder.removeAllListeners('drive-upload')
+    this.seeder.removeAllListeners('drive-peer-add')
+    this.seeder.removeAllListeners('drive-peer-remove')
     return this.seeder.destroy()
   }
 

--- a/packages/seeder/src/seeder.js
+++ b/packages/seeder/src/seeder.js
@@ -140,11 +140,15 @@ class Seeder extends EventEmitter {
       const getContentFeed = promisify(drive.getContent)
       const contentFeed = await getContentFeed()
 
+      contentFeed.on('peer-add', (...args) => this.onEvent('peer-add', key, ...args))
+      contentFeed.on('peer-remove', (...args) => this.onEvent('peer-remove', key, ...args))
       contentFeed.on('download', (...args) => this.onEvent('download', key, ...args))
       contentFeed.on('upload', (...args) => this.onEvent('upload', key, ...args))
       contentFeed.on('close', () => {
         contentFeed.removeListener('download', this.onEvent)
         contentFeed.removeListener('upload', this.onEvent)
+        contentFeed.removeListener('peer-add', this.onEvent)
+        contentFeed.removeListener('peer-remove', this.onEvent)
       })
 
       this.unwatches.set(keyString, unwatch)


### PR DESCRIPTION
This PR adds a demo endpoint on the `cli` package. The demo endpoint can be used to simulate vaults api response. 

Now, we can run `npm run demo` on the `cli` package.

Also made some tweaks , mostly on keys.updater.service and keys.service in order to make use of this response. 

