### PR TITLE
Fix: metrics db path on config creation command

### DIFF
--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -47,6 +47,7 @@ module.exports.init = (configFolderPath, options = {}) => {
 
   // Set initial runtime config
   this.set('keys.db.path', resolve(configFolderPath, 'keys.db'), { configFolderPath })
+  this.set('metrics.db.path', resolve(configFolderPath, 'metrics.db'), { configFolderPath })
   this.set('security.secret', randomBytes(32).toString('hex'), { configFolderPath })
 }
 


### PR DESCRIPTION
This PR fixes the metrics.db path that is created with the config:init command