### PR TITLE
Update: show hyperdrive version

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -58,6 +58,7 @@
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1",
+    "react-json-view": "^1.19.1",
     "react": "^16.13.1",
     "socket.io-client": "^2.3.0",
     "use-http": "^1.0.13",

--- a/packages/dashboard/src/components/DriveInfo.js
+++ b/packages/dashboard/src/components/DriveInfo.js
@@ -1,0 +1,107 @@
+import React from 'react'
+
+import { withStyles, makeStyles, useTheme } from '@material-ui/core/styles'
+import useMediaQuery from '@material-ui/core/useMediaQuery'
+import Chip from '@material-ui/core/Chip'
+import Dialog from '@material-ui/core/Dialog'
+import MuiDialogTitle from '@material-ui/core/DialogTitle'
+import MuiDialogContent from '@material-ui/core/DialogContent'
+import IconButton from '@material-ui/core/IconButton'
+import CloseIcon from '@material-ui/icons/Close'
+import Typography from '@material-ui/core/Typography'
+
+import ReactJson from 'react-json-view'
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    minWidth: '500px'
+  },
+  indexJSON: {
+  }
+}))
+
+const styles = (theme) => ({
+  root: {
+    margin: 0,
+    padding: theme.spacing(2)
+  },
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500]
+  }
+})
+
+const DialogTitle = withStyles(styles)((props) => {
+  const { children, classes, onClose, ...other } = props
+  return (
+    <MuiDialogTitle disableTypography className={classes.root} {...other}>
+      <Typography variant='h6'>{children}</Typography>
+      {onClose ? (
+        <IconButton aria-label='close' className={classes.closeButton} onClick={onClose}>
+          <CloseIcon />
+        </IconButton>
+      ) : null}
+    </MuiDialogTitle>
+  )
+})
+
+const DialogContent = withStyles((theme) => ({
+  root: {
+    padding: theme.spacing(2)
+  }
+}))(MuiDialogContent)
+
+function DriveInfo ({ info = {}, onClose, open }) {
+  const theme = useTheme()
+  const classes = useStyles()
+  const { version, indexJSON = {} } = info
+  const fullScreen = useMediaQuery(theme.breakpoints.down('md'))
+  const versionLabel = ({ version }) => (
+    <Chip
+      label={version}
+      color='secondary'
+      variant='outlined'
+    />
+  )
+
+  const titleLabel = (title = '') => (
+    <Typography variant='h5' color='primary' component='span' style={{ textTransform: 'capitalize' }} noWrap gutterBottom>
+      {title}
+    </Typography>
+  )
+
+  return (
+    <Dialog
+      scroll='paper'
+      fullScreen={fullScreen}
+      onClose={onClose}
+      aria-labelledby='drive-details-title'
+      open={open}
+      fullWidth
+    >
+      <DialogTitle id='drive-details-title' onClose={onClose}>
+        Drive Info{indexJSON.title ? ':' : ''} {titleLabel(indexJSON.title)}
+      </DialogTitle>
+      <DialogContent className={classes.root} dividers>
+        <div style={{ marginBottom: '1em' }}>
+          <Typography variant='overline' style={{ fontWeight: 'bold' }} display='block'>
+        Version
+          </Typography>
+          {versionLabel({ version })}
+        </div>
+        <div style={{ marginBottom: '1em' }}>
+          <Typography variant='overline' style={{ fontWeight: 'bold' }} display='block'>
+          index.json
+          </Typography>
+          <div className={classes.indexJSON}>
+            <ReactJson src={indexJSON} style={{ minWidth: '500px' }} displayDataTypes={false} indentWidth={2} collapseStringsAfterLength={15} />
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default DriveInfo

--- a/packages/dashboard/src/components/DriveInfo.js
+++ b/packages/dashboard/src/components/DriveInfo.js
@@ -1,11 +1,11 @@
 import React from 'react'
 
-import { withStyles, makeStyles, useTheme } from '@material-ui/core/styles'
+import { makeStyles, useTheme } from '@material-ui/core/styles'
 import useMediaQuery from '@material-ui/core/useMediaQuery'
 import Chip from '@material-ui/core/Chip'
 import Dialog from '@material-ui/core/Dialog'
 import MuiDialogTitle from '@material-ui/core/DialogTitle'
-import MuiDialogContent from '@material-ui/core/DialogContent'
+import DialogContent from '@material-ui/core/DialogContent'
 import IconButton from '@material-ui/core/IconButton'
 import CloseIcon from '@material-ui/icons/Close'
 import Typography from '@material-ui/core/Typography'
@@ -14,15 +14,10 @@ import ReactJson from 'react-json-view'
 
 const useStyles = makeStyles(theme => ({
   root: {
-    minWidth: '500px'
-  },
-  indexJSON: {
-  }
-}))
-
-const styles = (theme) => ({
-  root: {
     margin: 0,
+    padding: theme.spacing(2)
+  },
+  dialogContent: {
     padding: theme.spacing(2)
   },
   closeButton: {
@@ -31,10 +26,11 @@ const styles = (theme) => ({
     top: theme.spacing(1),
     color: theme.palette.grey[500]
   }
-})
+}))
 
-const DialogTitle = withStyles(styles)((props) => {
-  const { children, classes, onClose, ...other } = props
+const DialogTitle = (props) => {
+  const classes = useStyles()
+  const { children, onClose, ...other } = props
   return (
     <MuiDialogTitle disableTypography className={classes.root} {...other}>
       <Typography variant='h6'>{children}</Typography>
@@ -45,13 +41,7 @@ const DialogTitle = withStyles(styles)((props) => {
       ) : null}
     </MuiDialogTitle>
   )
-})
-
-const DialogContent = withStyles((theme) => ({
-  root: {
-    padding: theme.spacing(2)
-  }
-}))(MuiDialogContent)
+}
 
 function DriveInfo ({ info = {}, onClose, open }) {
   const theme = useTheme()
@@ -84,7 +74,7 @@ function DriveInfo ({ info = {}, onClose, open }) {
       <DialogTitle id='drive-details-title' onClose={onClose}>
         Drive Info{indexJSON.title ? ':' : ''} {titleLabel(indexJSON.title)}
       </DialogTitle>
-      <DialogContent className={classes.root} dividers>
+      <DialogContent className={classes.dialogContent} dividers>
         <div style={{ marginBottom: '1em' }}>
           <Typography variant='overline' style={{ fontWeight: 'bold' }} display='block'>
         Version
@@ -95,8 +85,14 @@ function DriveInfo ({ info = {}, onClose, open }) {
           <Typography variant='overline' style={{ fontWeight: 'bold' }} display='block'>
           index.json
           </Typography>
-          <div className={classes.indexJSON}>
-            <ReactJson src={indexJSON} style={{ minWidth: '500px' }} displayDataTypes={false} indentWidth={2} collapseStringsAfterLength={15} />
+          <div>
+            <ReactJson
+              src={indexJSON}
+              style={{ minWidth: '500px' }}
+              displayDataTypes={false}
+              indentWidth={2}
+              collapseStringsAfterLength={15}
+            />
           </div>
         </div>
       </DialogContent>

--- a/packages/dashboard/src/components/DriveItem.js
+++ b/packages/dashboard/src/components/DriveItem.js
@@ -53,15 +53,6 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-const Fold = (props) =>
-  (
-    <FoldIcon />
-  )
-
-const Unfold = (props) => (
-  <UnfoldIcon />
-)
-
 function DriveItem ({ driveKey }) {
   const classes = useStyles()
 
@@ -73,7 +64,7 @@ function DriveItem ({ driveKey }) {
   const [peers, setPeers] = useState([])
   const [driveInfo, setDriveInfo] = useState({})
   const [showInfo, setShowInfo] = useState(false)
-  const [showDetails, setShowDetails] = React.useState(false)
+  const [showDetails, setShowDetails] = useState(false)
 
   const { get, response, error } = useFetch(API_URL)
 
@@ -114,17 +105,19 @@ function DriveItem ({ driveKey }) {
         return
       }
 
-      const driveInfo = await get(`/drives/${driveKey}/info`)
-      if (!response.ok) {
-        console.warn(error)
-        return
-      }
       setTitle(drive.key.title)
       setSizeBlocks(drive.size.blocks)
       setSizeBytes(drive.size.bytes)
       setDownloadedBlocks(drive.size.downloadedBlocks)
       setFiles(drive.stats)
       setPeers(drive.peers)
+
+      const driveInfo = await get(`/drives/${driveKey}/info`)
+      if (!response.ok) {
+        console.warn(error)
+        return
+      }
+
       setDriveInfo(driveInfo)
     }
 
@@ -172,7 +165,7 @@ function DriveItem ({ driveKey }) {
                 </CopyToClipboard>
               </div>
               <Grid container alignItems='flex-start'>
-                <IconButton onClick={() => setShowInfo(showInfo => !showInfo)}>{showInfo ? <Fold /> : <Unfold />}</IconButton>
+                <IconButton onClick={() => setShowInfo(showInfo => !showInfo)}>{showInfo ? <FoldIcon /> : <UnfoldIcon />}</IconButton>
                 <IconButton aria-label='drive details' onClick={openDetails}><InfoIcon /></IconButton>
                 <DriveInfoDialog open={showDetails} onClose={closeDetails} info={driveInfo} />
               </Grid>

--- a/packages/sdk/src/services/api.service.js
+++ b/packages/sdk/src/services/api.service.js
@@ -36,6 +36,7 @@ module.exports = {
         'GET api/drives/:key/size': 'api.drives.size',
         'GET api/drives/:key/peers': 'api.drives.peers',
         'GET api/drives/:key/stats': 'api.drives.stats',
+        'GET api/drives/:key/info': 'api.drives.info',
         'GET api/stats/host': 'api.stats.host',
         'GET api/stats/network': 'api.stats.network'
       }
@@ -91,6 +92,12 @@ module.exports = {
       }
     },
 
+    'drives.info': {
+      async handler (ctx) {
+        return this.driveInfo(ctx.params.key)
+      }
+    },
+
     'drives.peers': {
       async handler (ctx) {
         return this.drivePeers(ctx.params.key)
@@ -121,6 +128,13 @@ module.exports = {
       async handler (key) {
         const size = await this.broker.call('seeder.driveSize', { key })
         return size
+      }
+    },
+
+    driveInfo: {
+      async handler (key) {
+        const info = await this.broker.call('seeder.driveInfo', { key })
+        return info
       }
     },
 

--- a/packages/sdk/src/services/seeder.service.js
+++ b/packages/sdk/src/services/seeder.service.js
@@ -30,6 +30,15 @@ module.exports = {
       }
     },
 
+    driveInfo: {
+      params: {
+        key: { type: 'string', length: '64', hex: true }
+      },
+      async handler (ctx) {
+        return this.driveInfo(ctx.params.key)
+      }
+    },
+
     driveSize: {
       params: {
         key: { type: 'string', length: '64', hex: true }
@@ -72,6 +81,10 @@ module.exports = {
 
     async unseed (key) {
       return this.seeder.unseed(key)
+    },
+
+    async driveInfo (key) {
+      return this.seeder.driveInfo(key)
     },
 
     driveSize (key) {

--- a/packages/seeder/src/drive.js
+++ b/packages/seeder/src/drive.js
@@ -35,7 +35,7 @@ class Drive extends EventEmitter {
     this._onReady = this._onReady.bind(this)
     this._hyperdrive.on('update', this._onUpdate)
 
-    this.getContentAsync = promisify(this._hyperdrive.getContent)
+    this._getContentAsync = promisify(this._hyperdrive.getContent)
   }
 
   get discoveryKey () {
@@ -130,11 +130,15 @@ class Drive extends EventEmitter {
     if (!this._ready) {
       return {}
     }
+
     let indexJSON = {}
+
     try {
       indexJSON = JSON.parse(await this._hyperdrive.readFile('index.json', 'utf-8'))
     } catch (_) {}
+
     const version = this._hyperdrive.version
+
     return {
       version,
       indexJSON
@@ -152,7 +156,7 @@ class Drive extends EventEmitter {
 
   async getContentFeed () {
     if (!this._contentFeed) {
-      this._contentFeed = await this.getContentAsync()
+      this._contentFeed = await this._getContentAsync()
     }
 
     return this._contentFeed

--- a/packages/seeder/src/seeder.js
+++ b/packages/seeder/src/seeder.js
@@ -149,6 +149,10 @@ class Seeder extends EventEmitter {
     return this.getDrive(key).peers
   }
 
+  async driveInfo (key) {
+    return this.getDrive(key).info()
+  }
+
   async driveNetwork (key) {
     const drive = this.getDrive(key)
     return this.networker.status(drive.discoveryKey)


### PR DESCRIPTION
This PR adds a new component: DriveInfo which is a dialog that shows the drive version and the `index.json` (if present). 
There is also a new API endpoint: `api/drives/key/info` used to extract this info. 
Finally, there is a new low level method `info`, added to our `drive` abstraction that collects this information.

Closes #53 