### PR TITLE
Seeder: Move stats and size to async+live methods

### DIFF
--- a/packages/sdk/src/services/seeder.service.js
+++ b/packages/sdk/src/services/seeder.service.js
@@ -87,7 +87,7 @@ module.exports = {
       return this.seeder.driveInfo(key)
     },
 
-    driveSize (key) {
+    async driveSize (key) {
       return this.seeder.driveSize(key)
     },
 
@@ -100,8 +100,9 @@ module.exports = {
       }))
     },
 
-    driveStats (key) {
-      return Object.fromEntries(this.seeder.driveStats(key))
+    async driveStats (key) {
+      const stats = await this.seeder.driveStats(key)
+      return Object.fromEntries(stats)
     },
 
     onDriveAdd (key) {

--- a/packages/seeder/src/seeder.js
+++ b/packages/seeder/src/seeder.js
@@ -136,16 +136,16 @@ class Seeder extends EventEmitter {
     }
   }
 
-  driveSize (key) {
-    return this.getDrive(key).size
+  async driveSize (key) {
+    return this.getDrive(key).getSize()
   }
 
-  driveStats (key) {
-    return this.getDrive(key).stats
+  async driveStats (key) {
+    return this.getDrive(key).getStats()
   }
 
-  driveLstat (key) {
-    return this.getDrive(key).lstat
+  async driveLstat (key) {
+    return this.getDrive(key).getLstat()
   }
 
   drivePeers (key) {


### PR DESCRIPTION
This PR changes the way some methods of `drive` are handled.