### PR TITLE
Update: stats db collections persisted

### DIFF
--- a/packages/cli/src/templates/permanent-seeder.template.toml
+++ b/packages/cli/src/templates/permanent-seeder.template.toml
@@ -24,3 +24,4 @@ path = 'keys.db'
 
 [metrics.db]
 path = 'metrics.db'
+save_stats = true

--- a/packages/dashboard/src/components/AddKeyDialog.js
+++ b/packages/dashboard/src/components/AddKeyDialog.js
@@ -7,8 +7,13 @@ import Button from '@material-ui/core/Button'
 import DialogActions from '@material-ui/core/DialogActions'
 import DialogContent from '@material-ui/core/DialogContent'
 import DialogTitle from '@material-ui/core/DialogTitle'
+import InputAdornment from '@material-ui/core/InputAdornment'
+import KeyIcon from '@material-ui/icons/VpnKey'
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
+  title: {
+    color: theme.palette.text.primary
+  },
   input: {
     fontFamily: 'monospace'
   }
@@ -38,10 +43,9 @@ function AddKeyDialog ({ open, keyToAdd = '', error, onClose, onAdd }) {
       fullWidth
       aria-labelledby='form-dialog-title'
     >
-      <DialogTitle id='form-dialog-title'>Add key</DialogTitle>
+      <DialogTitle id='form-dialog-title' className={classes.title}>Add Key</DialogTitle>
       <DialogContent>
         <TextField
-          label='Key'
           value={key}
           onChange={handleKeyChange}
           error={Boolean(error)}
@@ -53,13 +57,22 @@ function AddKeyDialog ({ open, keyToAdd = '', error, onClose, onAdd }) {
           fullWidth
           margin='dense'
           type='text'
+          color='primary'
+          variant='outlined'
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position='start'>
+                <KeyIcon />
+              </InputAdornment>
+            )
+          }}
         />
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} color='primary'>
+        <Button onClick={onClose}>
           Cancel
         </Button>
-        <Button onClick={handleAdd} color='primary'>
+        <Button onClick={handleAdd}>
           Add
         </Button>
       </DialogActions>

--- a/packages/dashboard/src/components/AppBar.js
+++ b/packages/dashboard/src/components/AppBar.js
@@ -12,7 +12,7 @@ import MenuIcon from '@material-ui/icons/Menu'
 import { DRAWER_WITH } from '../constants'
 import PSIcon from './PSIcon'
 
-import { useLeftSidebar, useAppBarTitle } from '../hooks/layout'
+import { useLeftSidebar, useAppBarTitle, useDarkMode } from '../hooks/layout'
 
 const useStyles = makeStyles((theme) => ({
   toolbar: {
@@ -49,10 +49,16 @@ function AppBar ({ drawerWith }) {
 
   const [open, setOpen] = useLeftSidebar()
   const [appBarTitle] = useAppBarTitle()
+  const [darkMode, setDarkMode] = useDarkMode()
 
   const handleDrawerOpen = () => {
     setOpen(true)
   }
+
+  const toggleDarkMode = () => {
+    setDarkMode(!darkMode)
+  }
+
   return (
     <MuiAppBar position='absolute' className={clsx(classes.appBar, open && classes.appBarShift)}>
       <Toolbar className={classes.toolbar}>
@@ -68,7 +74,7 @@ function AppBar ({ drawerWith }) {
         <Typography component='h1' variant='h6' color='inherit' noWrap className={classes.title}>
           {appBarTitle}
         </Typography>
-        <IconButton color='inherit' size='small' disableRipple disableFocusRipple>
+        <IconButton color='inherit' size='small' disableRipple disableFocusRipple onClick={toggleDarkMode}>
           <PSIcon fontSize='large' />
         </IconButton>
       </Toolbar>

--- a/packages/dashboard/src/components/DriveFiles.js
+++ b/packages/dashboard/src/components/DriveFiles.js
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { makeStyles } from '@material-ui/core/styles'
 import Paper from '@material-ui/core/Paper'
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
@@ -10,13 +11,28 @@ import TableRow from '@material-ui/core/TableRow'
 
 import { humanizedBytes } from '../format'
 
+const useStyles = makeStyles({
+  container: {
+    maxHeight: 440
+  },
+  table: {
+    width: '100%',
+    tableLayout: 'fixed'
+  },
+  cellFile: {
+    width: '65%'
+  }
+})
+
 function DriveFiles ({ files }) {
+  const classes = useStyles()
+
   return (
-    <TableContainer square component={Paper}>
-      <Table aria-label='simple table'>
+    <TableContainer square component={Paper} className={classes.container}>
+      <Table stickyHeader aria-label="drive's file contents table" className={classes.table}>
         <TableHead>
           <TableRow>
-            <TableCell>File</TableCell>
+            <TableCell className={classes.cellFile}>File</TableCell>
             <TableCell align='right'>Size</TableCell>
             <TableCell align='right'>Blocks</TableCell>
           </TableRow>
@@ -24,7 +40,7 @@ function DriveFiles ({ files }) {
         <TableBody>
           {Object.entries(files).map(([fileName, { size, blocks }]) => (
             <TableRow key={fileName}>
-              <TableCell>{fileName}</TableCell>
+              <TableCell size='small' className={classes.cellFile}>{fileName}</TableCell>
               <TableCell align='right'>{humanizedBytes(size).pretty}</TableCell>
               <TableCell align='right'>{blocks}</TableCell>
             </TableRow>

--- a/packages/dashboard/src/components/DriveInfo.js
+++ b/packages/dashboard/src/components/DriveInfo.js
@@ -62,6 +62,10 @@ function DriveInfo ({ info = {}, onClose, open }) {
     </Typography>
   )
 
+  const handleCopy = (copy) => {
+    navigator.clipboard.writeText(JSON.stringify(copy.src, null, '\t'))
+  }
+
   return (
     <Dialog
       scroll='paper'
@@ -92,6 +96,7 @@ function DriveInfo ({ info = {}, onClose, open }) {
               displayDataTypes={false}
               indentWidth={2}
               collapseStringsAfterLength={15}
+              enableClipboard={handleCopy}
             />
           </div>
         </div>

--- a/packages/dashboard/src/components/DriveInfo.js
+++ b/packages/dashboard/src/components/DriveInfo.js
@@ -6,6 +6,7 @@ import Chip from '@material-ui/core/Chip'
 import Dialog from '@material-ui/core/Dialog'
 import MuiDialogTitle from '@material-ui/core/DialogTitle'
 import DialogContent from '@material-ui/core/DialogContent'
+import Paper from '@material-ui/core/Paper'
 import IconButton from '@material-ui/core/IconButton'
 import CloseIcon from '@material-ui/icons/Close'
 import Typography from '@material-ui/core/Typography'
@@ -13,9 +14,13 @@ import Typography from '@material-ui/core/Typography'
 import ReactJson from 'react-json-view'
 
 const useStyles = makeStyles(theme => ({
-  root: {
+  dialogTitle: {
     margin: 0,
     padding: theme.spacing(2)
+  },
+  dialogSubTitle: {
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2)
   },
   dialogContent: {
     padding: theme.spacing(2)
@@ -28,11 +33,27 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
+const TitleLabel = props => (
+  <Typography
+    variant='h6'
+    color='textSecondary'
+    component='span'
+    style={{
+      textTransform: 'capitalize',
+      textOverflow: 'ellipsis'
+    }}
+    noWrap
+    className={props.className}
+  >
+    {props.title || ''}
+  </Typography>
+)
+
 const DialogTitle = (props) => {
   const classes = useStyles()
   const { children, onClose, ...other } = props
   return (
-    <MuiDialogTitle disableTypography className={classes.root} {...other}>
+    <MuiDialogTitle disableTypography className={classes.dialogTitle} {...other}>
       <Typography variant='h6'>{children}</Typography>
       {onClose ? (
         <IconButton aria-label='close' className={classes.closeButton} onClick={onClose}>
@@ -56,12 +77,6 @@ function DriveInfo ({ info = {}, onClose, open }) {
     />
   )
 
-  const titleLabel = (title = '') => (
-    <Typography variant='h5' color='primary' component='span' style={{ textTransform: 'capitalize' }} noWrap gutterBottom>
-      {title}
-    </Typography>
-  )
-
   const handleCopy = (copy) => {
     navigator.clipboard.writeText(JSON.stringify(copy.src, null, '\t'))
   }
@@ -75,9 +90,10 @@ function DriveInfo ({ info = {}, onClose, open }) {
       open={open}
       fullWidth
     >
-      <DialogTitle id='drive-details-title' onClose={onClose}>
-        Drive Info{indexJSON.title ? ':' : ''} {titleLabel(indexJSON.title)}
+      <DialogTitle id='drive-details-title' className={classes.dialogTitle} onClose={onClose}>
+        Drive Info
       </DialogTitle>
+      <TitleLabel title={indexJSON.title} className={classes.dialogSubTitle} />
       <DialogContent className={classes.dialogContent} dividers>
         <div style={{ marginBottom: '1em' }}>
           <Typography variant='overline' style={{ fontWeight: 'bold' }} display='block'>
@@ -89,16 +105,18 @@ function DriveInfo ({ info = {}, onClose, open }) {
           <Typography variant='overline' style={{ fontWeight: 'bold' }} display='block'>
           index.json
           </Typography>
-          <div>
+
+          <Paper>
             <ReactJson
               src={indexJSON}
-              style={{ minWidth: '500px' }}
+              style={{ minWidth: '500px', borderRadius: theme.shape.borderRadius, padding: theme.spacing(1), fontSize: theme.typography.fontSize }}
               displayDataTypes={false}
               indentWidth={2}
               collapseStringsAfterLength={15}
               enableClipboard={handleCopy}
+              theme='solarized'
             />
-          </div>
+          </Paper>
         </div>
       </DialogContent>
     </Dialog>

--- a/packages/dashboard/src/components/DriveItemHeader.js
+++ b/packages/dashboard/src/components/DriveItemHeader.js
@@ -1,7 +1,8 @@
 import React, { useMemo } from 'react'
 
 import { makeStyles } from '@material-ui/core'
-import Button from '@material-ui/core/Button'
+import IconButton from '@material-ui/core/IconButton'
+import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline'
 import Grid from '@material-ui/core/Grid'
 import Typography from '@material-ui/core/Typography'
 
@@ -43,15 +44,16 @@ function DriveItemHeader ({ onKeyAdd }) {
     ['Drive Key', {
       className: classes.driveKeyHeader,
       extra: (
-        <Button
+        <IconButton
+          aria-label='add key'
           onClick={onKeyAdd}
           color='primary'
           variant='outlined'
           size='small'
           className={classes.addKeyButton}
         >
-          Add key
-        </Button>
+          <AddCircleOutlineIcon />
+        </IconButton>
       )
     }],
     ['Size', { }],

--- a/packages/dashboard/src/components/NetworkIndicator.js
+++ b/packages/dashboard/src/components/NetworkIndicator.js
@@ -23,7 +23,7 @@ const useNetworkIconStyles = makeStyles(theme => ({
 
 function NetworkIndicator () {
   const networkIconClasses = useNetworkIconStyles()
-  const [network, setNetwork] = useState({ swarm: {} })
+  const [network, setNetwork] = useState({ swarm: { currentPeers: [] } })
   const { data: lastMessageNetwork, unsubscribe } = useLastMessage('stats.network')
 
   useEffect(() => {
@@ -65,6 +65,12 @@ function NetworkIndicator () {
               label='Address'
               value={
                 <StatusChip label={network.swarm.remoteAddress} />
+              }
+            />
+            <TooltipInfoItem
+              label='Peers'
+              value={
+                <StatusChip label={network.swarm.currentPeers.length} />
               }
             />
           </Grid>

--- a/packages/dashboard/src/components/StatusChip.js
+++ b/packages/dashboard/src/components/StatusChip.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles(theme => ({
 
 const useChipStyles = makeStyles(theme => ({
   label: {
-    color: theme.palette.common.black
+    color: theme.palette.type === 'light' ? theme.palette.common.black : theme.palette.common.white
   },
 
   colorPrimary: {

--- a/packages/dashboard/src/containers/App.js
+++ b/packages/dashboard/src/containers/App.js
@@ -8,7 +8,7 @@ import CssBaseline from '@material-ui/core/CssBaseline'
 
 import { play, exit } from '../timeline'
 
-import { AppStateProvider } from '../context/app-state'
+import { useDarkMode } from '../hooks/layout'
 
 import Layout from '../components/Layout'
 import NoMatch from '../components/NoMatch'
@@ -29,33 +29,10 @@ const ethSansTTF = {
   `
 }
 
-const theme = createMuiTheme({
-  typography: {
-    fontFamilyGEUT: 'ethon, Arial'
-  },
-  overrides: {
-    MuiCssBaseline: {
-      '@global': {
-        '@font-face': [ethSansTTF]
-      }
-    }
-  },
-  palette: {
-    primary: {
-      main: '#7800D2',
-      light: '#ad47ff',
-      dark: '#3e009f'
-    },
-    secondary: {
-      main: '#5bd200',
-      light: '#93ff4d',
-      dark: '#0ca000'
-    }
-  }
-})
-
 function AppContainer () {
   const [intro, setIntro] = useState(true)
+  const [darkMode] = useDarkMode()
+
   useEffect(() => {
     async function delay () {
       await new Promise(resolve => setTimeout(resolve, 1700))
@@ -65,45 +42,69 @@ function AppContainer () {
     delay()
   }, [])
 
+  const theme = createMuiTheme({
+    typography: {
+      fontFamilyGEUT: 'ethon, Arial'
+    },
+    overrides: {
+      MuiCssBaseline: {
+        '@global': {
+          '@font-face': [ethSansTTF]
+        }
+      }
+    },
+    palette: {
+      type: darkMode ? 'dark' : 'light',
+      primary: {
+        main: '#7800D2',
+        light: '#ae47ff',
+        dark: '#3f009f'
+      },
+      secondary: {
+        main: '#5bd200',
+        light: '#93ff4d',
+        dark: '#0ca000'
+      }
+    }
+  })
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <SocketIOProvider url='http://localhost:3001'>
-        <AppStateProvider>
-          <Router>
-            <Layout>
-              <Route render={({ location }) => {
-                const { pathname, key } = location
+        <Router>
+          <Layout>
+            <Route render={({ location }) => {
+              const { pathname, key } = location
 
-                return (
-                  <TransitionGroup component={null}>
-                    <Transition
-                      key={key}
-                      appear
-                      onEnter={(node, appears) => play(pathname, node, appears)}
-                      onExit={(node, appears) => exit(node, appears)}
-                      timeout={{ enter: 750, exit: 250 }}
-                    >
-                      <Switch>
-                        <Route exact path='/'>
-                          {intro ? <SplashScreen /> : <Redirect to='/dashboard' />}
-                        </Route>
-                        <Route path='/dashboard'>
-                          <Dashboard />
-                        </Route>
-                        <Route path='*'>
-                          <NoMatch />
-                        </Route>
-                      </Switch>
-                    </Transition>
-                  </TransitionGroup>
-                )
-              }}
-              />
+              return (
+                <TransitionGroup component={null}>
+                  <Transition
+                    key={key}
+                    appear
+                    onEnter={(node, appears) => play(pathname, node, appears)}
+                    onExit={(node, appears) => exit(node, appears)}
+                    timeout={{ enter: 750, exit: 250 }}
+                  >
+                    <Switch>
+                      <Route exact path='/'>
+                        {intro ? <SplashScreen /> : <Redirect to='/dashboard' />}
+                      </Route>
+                      <Route path='/dashboard'>
+                        <Dashboard />
+                      </Route>
+                      <Route path='*'>
+                        <NoMatch />
+                      </Route>
+                    </Switch>
+                  </Transition>
+                </TransitionGroup>
+              )
+            }}
+            />
 
-            </Layout>
-          </Router>
-        </AppStateProvider>
+          </Layout>
+        </Router>
       </SocketIOProvider>
     </ThemeProvider>
   )

--- a/packages/dashboard/src/context/app-state.js
+++ b/packages/dashboard/src/context/app-state.js
@@ -1,9 +1,20 @@
 import React, { useReducer, useMemo } from 'react'
 
+const getLocalStorage = (key) => {
+  if (!window.localStorage) return false
+  return (window.localStorage.getItem(key, false)) === 'true'
+}
+
+const setLocalStorage = (key, value) => {
+  if (!window.localStorage) return
+  window.localStorage.setItem(key, value)
+}
+
 const initialState = {
   ui: {
     leftSidebarOpen: false,
-    appBarTitle: 'Home'
+    appBarTitle: 'Home',
+    darkMode: getLocalStorage('permanent-seeder.darkMode')
   }
 }
 
@@ -16,6 +27,10 @@ function reducer (state, action) {
       break
     case 'ui.appBar.title':
       newState.ui.appBarTitle = action.payload
+      break
+    case 'ui.darkMode':
+      setLocalStorage('permanent-seeder.darkMode', action.payload)
+      newState.ui.darkMode = action.payload
       break
     default:
       throw new Error()

--- a/packages/dashboard/src/hooks/layout.js
+++ b/packages/dashboard/src/hooks/layout.js
@@ -27,3 +27,16 @@ export function useAppBarTitle () {
     setAppBarTitle
   ]
 }
+
+export function useDarkMode () {
+  const { state: { ui: { darkMode } }, dispatch } = useContext(AppStateContext)
+
+  const setDarkMode = (dark) => {
+    dispatch({ type: 'ui.darkMode', payload: dark })
+  }
+
+  return [
+    darkMode,
+    setDarkMode
+  ]
+}

--- a/packages/dashboard/src/index.js
+++ b/packages/dashboard/src/index.js
@@ -4,9 +4,12 @@ import ReactDOM from 'react-dom'
 import * as serviceWorker from './serviceWorker'
 
 import App from './containers/App'
+import { AppStateProvider } from './context/app-state'
 
 ReactDOM.render(
-  <App />
+  <AppStateProvider>
+    <App />
+  </AppStateProvider>
   ,
   document.getElementById('root')
 )

--- a/packages/database/src/metrics-database.js
+++ b/packages/database/src/metrics-database.js
@@ -17,7 +17,7 @@ class MetricsDatabase extends Database {
     this.by.timestamp = AutoIndex(this.metrics, this.idx.timestamp, (datum = {}) => {
       return datum.key + '!' + datum.timestamp
     })
-    this.by.event = AutoIndex(this.metrics, this.idx.timestamp, (datum = {}) => {
+    this.by.event = AutoIndex(this.metrics, this.idx.event, (datum = {}) => {
       return datum.key + '!' + datum.event
     })
   }
@@ -95,6 +95,30 @@ class MetricsDatabase extends Database {
             }
           } else {
             if (data.key.toString('hex') === key && data.timestamp >= query) {
+              out.push(data)
+            }
+          }
+        })
+        .on('end', () => resolve(out))
+        .on('error', reject)
+    })
+  }
+
+  async filterByEvent (key, query) {
+    assert(key, 'key is required')
+    return new Promise((resolve, reject) => {
+      const stream = this.by.event.createValueStream({
+        gte: key
+      })
+      const out = []
+      stream
+        .on('data', data => {
+          if (!query) {
+            if (data.key.toString('hex') === key) {
+              out.push(data)
+            }
+          } else {
+            if (data.key.toString('hex') === key && data.event === query) {
               out.push(data)
             }
           }

--- a/packages/database/src/metrics-database.js
+++ b/packages/database/src/metrics-database.js
@@ -50,13 +50,13 @@ class MetricsDatabase extends Database {
    * @returns {boolean} true if existent and key was updated
    */
   async add (data, updateIfExists = false) {
-    const existent = await this.get(data.key, data.timestamp)
+    const existent = await this.get(data.key, data.timestamp, data.event)
 
     if (existent && !updateIfExists) {
       throw new Error('Key already exists')
     }
 
-    await this.set(data.key, data.timestamp, data)
+    await this.set(data.key, data.timestamp, data.event, data)
 
     return !!existent
   }
@@ -69,13 +69,13 @@ class MetricsDatabase extends Database {
    * @returns {boolean} true if not existent and key was created
    */
   async update (data, createIfNotExists = false) {
-    const existent = await this.get(data.key, data.timestamp)
+    const existent = await this.get(data.key, data.timestamp, data.event)
 
     if (!existent && !createIfNotExists) {
       throw new Error('Key not created')
     }
 
-    await this.set(data.key, data.timestamp, data)
+    await this.set(data.key, data.timestamp, data.event, data)
 
     return !existent
   }

--- a/packages/database/src/metrics-database.js
+++ b/packages/database/src/metrics-database.js
@@ -10,11 +10,15 @@ class MetricsDatabase extends Database {
     this.metrics = sub(this._db, 'metrics', { valueEncoding: 'json' })
     this.idx = {
       key: sub(this._db, 'metrics-key'),
-      timestamp: sub(this._db, 'metrics-timestamp')
+      timestamp: sub(this._db, 'metrics-timestamp'),
+      event: sub(this._db, 'metrics-event')
     }
     this.by = {}
     this.by.timestamp = AutoIndex(this.metrics, this.idx.timestamp, (datum = {}) => {
       return datum.key + '!' + datum.timestamp
+    })
+    this.by.event = AutoIndex(this.metrics, this.idx.timestamp, (datum = {}) => {
+      return datum.key + '!' + datum.event
     })
   }
 

--- a/packages/database/src/metrics-database.js
+++ b/packages/database/src/metrics-database.js
@@ -50,15 +50,7 @@ class MetricsDatabase extends Database {
    * @returns {boolean} true if existent and key was updated
    */
   async add (data, updateIfExists = false) {
-    const existent = await this.get(data.key, data.timestamp, data.event)
-
-    if (existent && !updateIfExists) {
-      throw new Error('Key already exists')
-    }
-
     await this.set(data.key, data.timestamp, data.event, data)
-
-    return !!existent
   }
 
   /**

--- a/packages/database/tests/metrics-database.test.js
+++ b/packages/database/tests/metrics-database.test.js
@@ -83,8 +83,6 @@ test('get/add key', async () => {
 
   await metricsDB.add(data)
 
-  expect(metricsDB.add(data)).rejects.toBeTruthy()
-
   data.title = 'updated-key'
   await metricsDB.add(data, true)
 

--- a/packages/database/tests/metrics-database.test.js
+++ b/packages/database/tests/metrics-database.test.js
@@ -88,7 +88,7 @@ test('get/add key', async () => {
   data.title = 'updated-key'
   await metricsDB.add(data, true)
 
-  const dataKey = [data.key.toString('hex'), data.timestamp]
+  const dataKey = [data.key.toString('hex'), data.timestamp, data.event]
   const createdKey = await metricsDB.get(...dataKey)
   expect(createdKey).toMatchObject(data)
 })
@@ -110,7 +110,7 @@ test('get all keys', async () => {
 test('update key', async () => {
   const data = createRandomKeyData()
 
-  const dataKey = [data.key, data.timestamp]
+  const dataKey = [data.key, data.timestamp, data.event]
   await metricsDB.add(data)
   const createdKey = await metricsDB.get(...dataKey)
 
@@ -130,7 +130,7 @@ test('remove key', async () => {
 
   await metricsDB.add(data)
 
-  const dataKey = [data.key, data.timestamp]
+  const dataKey = [data.key, data.timestamp, data.event]
   await metricsDB.remove(...dataKey)
   await metricsDB.remove('not-present')
 

--- a/packages/database/tests/metrics-database.test.js
+++ b/packages/database/tests/metrics-database.test.js
@@ -13,6 +13,7 @@ const createRandomKeyData = () => {
   return {
     key,
     timestamp: Date.now(),
+    event: 'test.event',
     drive: {
       size: 1024,
       atime: '2017-04-10T18:59:00.147Z',

--- a/packages/sdk/src/services/api.service.js
+++ b/packages/sdk/src/services/api.service.js
@@ -3,6 +3,7 @@ const path = require('path')
 const ApiGatewayService = require('moleculer-web')
 const IO = require('socket.io')
 const compression = require('compression')
+const { encode } = require('dat-encoding')
 
 module.exports = {
   name: 'api',
@@ -122,7 +123,7 @@ module.exports = {
     'drives.add': {
       async handler (ctx) {
         await ctx.call('keys.add', {
-          key: ctx.params.key,
+          key: encode(ctx.params.key),
           title: Date.now().toString()
         })
       }

--- a/packages/sdk/src/services/api.service.js
+++ b/packages/sdk/src/services/api.service.js
@@ -39,8 +39,10 @@ module.exports = {
         'GET api/drives/:key/info': 'api.drives.info',
         'GET api/stats/host': 'api.stats.host',
         'GET api/stats/network': 'api.stats.network',
-
         'POST api/drives': 'api.drives.add'
+
+        'GET api/raw/:key': 'api.raw',
+        'GET api/raw/:key/:event': 'api.raw.event'
       }
     }],
 
@@ -136,6 +138,16 @@ module.exports = {
     'stats.host': {
       async handler (ctx) {
         return ctx.call('metrics.getHostStats')
+      }
+    },
+    raw: {
+      async handler (ctx) {
+        return this.raw(ctx.params.key)
+      }
+    },
+    'raw.event': {
+      async handler (ctx) {
+        return this.raw(ctx.params.key, ctx.params.event)
       }
     }
   },

--- a/packages/sdk/src/services/api.service.js
+++ b/packages/sdk/src/services/api.service.js
@@ -39,10 +39,9 @@ module.exports = {
         'GET api/drives/:key/info': 'api.drives.info',
         'GET api/stats/host': 'api.stats.host',
         'GET api/stats/network': 'api.stats.network',
+        'GET api/raw/:key': 'api.raw',
         'POST api/drives': 'api.drives.add'
 
-        'GET api/raw/:key': 'api.raw',
-        'GET api/raw/:key/:event': 'api.raw.event'
       }
     }],
 
@@ -205,6 +204,13 @@ module.exports = {
         }
 
         return key ? drives[0] : drives
+      }
+    },
+    raw: {
+      async handler (key, timestamp) {
+        // get all keys from timestamp (optional)
+        const stats = await this.broker.call('metrics.get', { key, timestamp })
+        return stats
       }
     }
   },

--- a/packages/sdk/src/services/metrics.service.js
+++ b/packages/sdk/src/services/metrics.service.js
@@ -23,9 +23,13 @@ module.exports = {
     'seeder.drive.stats': {
       async handler (ctx) {
         console.log(ctx)
-        await this.database.add(ctx.params)
+        const timestamp = Date.now()
+        const { key, ...data } = ctx.params
+        const event = ctx.eventName
+        await this.database.add({ key, timestamp, event, data })
       }
     }
+
   },
 
   actions: {

--- a/packages/sdk/src/services/metrics.service.js
+++ b/packages/sdk/src/services/metrics.service.js
@@ -22,7 +22,6 @@ module.exports = {
   events: {
     'seeder.drive.stats': {
       async handler (ctx) {
-        console.log(ctx)
         const timestamp = Date.now()
         const { key, ...data } = ctx.params
         const event = ctx.eventName

--- a/packages/sdk/src/services/metrics.service.js
+++ b/packages/sdk/src/services/metrics.service.js
@@ -20,8 +20,9 @@ module.exports = {
   mixins: [Config],
 
   events: {
-    'seeder.stats': {
+    'seeder.drive.stats': {
       async handler (ctx) {
+        console.log(ctx)
         await this.database.add(ctx.params)
       }
     }

--- a/packages/sdk/src/services/seeder.service.js
+++ b/packages/sdk/src/services/seeder.service.js
@@ -88,11 +88,22 @@ module.exports = {
     },
 
     async driveSize (key) {
-      return this.seeder.driveSize(key)
+      let size = {}
+      try {
+        size = await this.seeder.driveSize(key)
+      } catch (err) {
+        this.logger.error(err)
+      }
+      return size
     },
 
-    drivePeers (key) {
-      const peers = this.seeder.drivePeers(key)
+    async drivePeers (key) {
+      let peers = []
+      try {
+        peers = await this.seeder.drivePeers(key)
+      } catch (err) {
+        this.logger.error(err)
+      }
 
       return peers.map(peer => ({
         remoteAddress: peer.remoteAddress,
@@ -101,13 +112,21 @@ module.exports = {
     },
 
     async driveStats (key) {
-      const stats = await this.seeder.driveStats(key)
-      this.broker.broadcast('seeder.drive.stats', { key, stats, event: 'drive.stats' })
+      let stats = new Map()
+      try {
+        stats = await this.seeder.driveStats(key)
+      } catch (err) {
+        this.logger.error(err)
+      }
       return Object.fromEntries(stats)
     },
 
     onDriveAdd (key) {
       this.broker.broadcast('seeder.drive.add', { key })
+    },
+
+    onDriveUpdate (key) {
+      this.broker.broadcast('seeder.drive.update', { key })
     },
 
     onDriveRemove (key) {
@@ -141,6 +160,7 @@ module.exports = {
     const keys = await this.broker.call('keys.getAll')
 
     this.seeder.on('drive-add', this.onDriveAdd)
+    this.seeder.on('drive-update', this.onDriveUpdate)
     this.seeder.on('drive-remove', this.onDriveRemove)
     this.seeder.on('drive-download', this.onDriveDownload)
     this.seeder.on('drive-upload', this.onDriveUpload)

--- a/packages/sdk/src/services/seeder.service.js
+++ b/packages/sdk/src/services/seeder.service.js
@@ -102,7 +102,7 @@ module.exports = {
 
     async driveStats (key) {
       const stats = await this.seeder.driveStats(key)
-      this.broker.broadcast('seeder.drive.stats', { key, stats })
+      this.broker.broadcast('seeder.drive.stats', { key, stats, event: 'drive.stats' })
       return Object.fromEntries(stats)
     },
 

--- a/packages/sdk/src/services/seeder.service.js
+++ b/packages/sdk/src/services/seeder.service.js
@@ -102,6 +102,7 @@ module.exports = {
 
     async driveStats (key) {
       const stats = await this.seeder.driveStats(key)
+      this.broker.broadcast('seeder.drive.stats', { key, stats })
       return Object.fromEntries(stats)
     },
 

--- a/packages/seeder/src/drive.js
+++ b/packages/seeder/src/drive.js
@@ -42,7 +42,7 @@ class Drive extends EventEmitter {
     return this._hyperdrive.discoveryKey
   }
 
-  peers () {
+  get peers () {
     return this._hyperdrive.peers
   }
 

--- a/packages/seeder/src/drive.js
+++ b/packages/seeder/src/drive.js
@@ -24,6 +24,8 @@ class Drive extends EventEmitter {
     }
 
     this._hyperdrive = hyperdrive(store, key, this._opts)
+    this._key = key
+    this._store = store
     this._download = null
     this._contentFeed = null
 
@@ -40,8 +42,8 @@ class Drive extends EventEmitter {
     return this._hyperdrive.discoveryKey
   }
 
-  get peers () {
-    return this._contentFeed ? this._contentFeed.peers : []
+  peers () {
+    return this._hyperdrive.peers
   }
 
   async _onUpdate () {

--- a/packages/seeder/src/seeder.js
+++ b/packages/seeder/src/seeder.js
@@ -147,7 +147,7 @@ class Seeder extends EventEmitter {
   }
 
   drivePeers (key) {
-    return this.getDrive(key).peers
+    return this.getDrive(key).peers()
   }
 
   async driveInfo (key) {
@@ -175,7 +175,17 @@ class Seeder extends EventEmitter {
     const { holepunched, bootstrapped } = await this.connectivity()
     const ra = this.networker.swarm.remoteAddress()
     const remoteAddress = ra ? `${ra.host}:${ra.port}` : ''
-    const currentPeers = this.networker.peers
+    const currentPeers = Array
+      .from(this.networker.peers.values())
+      .reduce((acc, curr) => {
+        acc.push({
+          remoteAddress: curr.remoteAddress,
+          type: curr.type,
+          bytesSent: curr.stream.bytesSent,
+          bytesReceived: curr.stream.bytesReceived
+        })
+        return acc
+      }, [])
 
     return {
       holepunchable: holepunched,

--- a/packages/seeder/src/seeder.js
+++ b/packages/seeder/src/seeder.js
@@ -147,7 +147,7 @@ class Seeder extends EventEmitter {
   }
 
   drivePeers (key) {
-    return this.getDrive(key).peers()
+    return this.getDrive(key).peers
   }
 
   async driveInfo (key) {


### PR DESCRIPTION
This PR re-enables the stats storage. It also adds a new config property, which is enabled by default, called: `save_stats` under the `metrics.db` field. This new property indicates if we want to save or not db stats (which can be quite intensive). The stats can be collected by performing a GET request to `/api/raw/:key`. 

The PR also introduces some minor UI tweaks.

Closes #79 