### PR TITLE
Update: standalone release tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,8 @@ permanent-seeder.toml
 
 # Default DB name
 */**/keys.db
+
+# shrinkwrap
+npm-shrinkwrap.json
+
+packages/cli/tmp

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,9 +32,9 @@
   "scripts": {
     "demo": "npx http-server ./demo -p 8383",
     "lint": "xd-ns \"**/*.js\"",
-    "prepack": "oclif-dev manifest && oclif-dev readme & npm shrinkwrap",
+    "prepack": "oclif-dev manifest && oclif-dev readme",
     "postpack": "rm -f oclif.manifest.json",
-    "tarballs": "oclif-dev pack",
+    "tarballs": "cp ../../package-lock.json . && oclif-dev pack",
     "prepublishOnly": "npm test",
     "test": "jest --passWithNoTests --runInBand --detectOpenHandles --forceExit",
     "posttest": "npm run lint",
@@ -55,6 +55,8 @@
     "@oclif/errors": "^1.3.3",
     "@oclif/plugin-autocomplete": "^0.2.0",
     "@oclif/plugin-help": "^3.1.0",
+    "@oclif/plugin-update": "^1.3.10",
+    "@oclif/plugin-warn-if-update-available": "^1.7.0",
     "cli-ux": "^5.5.0",
     "colors": "^1.4.0",
     "dat-encoding": "^5.0.1",
@@ -84,8 +86,19 @@
     "bin": "permanent-seeder",
     "plugins": [
       "@oclif/plugin-autocomplete",
-      "@oclif/plugin-help"
-    ]
+      "@oclif/plugin-help",
+      "@oclif/plugin-update",
+      "@oclif/plugin-warn-if-update-available"
+    ],
+    "update": {
+      "s3": {
+        "host": "https://github.com/geut/permanent-seeder/packages/cli/dist"
+      }
+    },
+    "warn-if-update-available": {
+      "timeoutInDays": 2,
+      "message": "<%= config.name %> update available from <%= chalk.greenBright(config.version) %> to <%= chalk.greenBright(latest) %>."
+    }
   },
   "standard": {
     "env": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@geut/permanent-seeder",
   "version": "0.0.1",
-  "description": "Permanent Seeder cli",
+  "description": "Permanent Seeder CLI",
   "keywords": [
     "seeder",
     "geut"
@@ -32,8 +32,9 @@
   "scripts": {
     "demo": "npx http-server ./demo -p 8383",
     "lint": "xd-ns \"**/*.js\"",
-    "prepack": "oclif-dev manifest && oclif-dev readme",
+    "prepack": "oclif-dev manifest && oclif-dev readme & npm shrinkwrap",
     "postpack": "rm -f oclif.manifest.json",
+    "tarballs": "oclif-dev pack",
     "prepublishOnly": "npm test",
     "test": "jest --passWithNoTests --runInBand --detectOpenHandles --forceExit",
     "posttest": "npm run lint",

--- a/packages/cli/src/commands/dashboard.js
+++ b/packages/cli/src/commands/dashboard.js
@@ -1,0 +1,12 @@
+const BaseCommand = require('../base-command')
+const { cli } = require('cli-ux')
+
+class DashboardCommand extends BaseCommand {
+  async run () {
+    await cli.open('http://localhost:3001/')
+  }
+}
+
+DashboardCommand.description = 'Open the Permanent Seeder dashboard in the browser'
+
+module.exports = DashboardCommand

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,6 +14,9 @@
     "type": "git",
     "url": "git+https://github.com/geut/permanent-seeder.git"
   },
+  "files": [
+    "/build"
+  ],
   "license": "MIT",
   "author": {
     "name": "GEUT",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@geut/permanent-seeder-core": "^0.0.1",
+    "@geut/permanent-seeder-dashboard": "^0.0.1",
     "@geut/permanent-seeder-database": "^0.0.1",
     "compression": "^1.7.4",
     "deep-equal": "^2.0.3",

--- a/packages/sdk/src/services/api.service.js
+++ b/packages/sdk/src/services/api.service.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const { join } = require('path')
 
 const ApiGatewayService = require('moleculer-web')
 const IO = require('socket.io')
@@ -21,7 +21,7 @@ module.exports = {
 
     // Dashboard site
     assets: {
-      folder: path.resolve(__dirname, '../../../dashboard/build')
+      folder: join(__dirname, '../', '../', 'node_modules', '@geut', 'permanent-seeder-dashboard', 'build')
     },
 
     whitelist: [


### PR DESCRIPTION
This PR adds some initial work around standalone oclif releases.  Sadly, I wasn't able to `pack` the CLI locally. This was due to `oclif-dev` couldn't find the dependencies even after running  a `lerna link`. So I think, we can do a lerna publish beta first and then try the pack again to see if the generated tarballs has all the necessary things. 

In that essence, this PR does some tweaks like including the dashboard package as a dep of the sdk module. So, when a user installs from the tarball or npm, they would have the dashboard build included right away. The PR also includes a handy `dashboard` command that opens a browser with the dashboard. 

Related to #78 