### PR TITLE
Add makefile helpers, Dockerfile and compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-.mk-libs
+.mk-lib
 Dockerfile
 docker-compose.yml
 Makefile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.mk-libs
+Dockerfile
+docker-compose.yml
+Makefile

--- a/.mk-lib/HEADER.mk
+++ b/.mk-lib/HEADER.mk
@@ -1,0 +1,6 @@
+# REQUIRED SECTION
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+include $(ROOT_DIR)/.mk-lib/common.mk
+# END OF REQUIRED SECTION
+
+# Insert your code here

--- a/.mk-lib/LICENSE
+++ b/.mk-lib/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Roman Kudlay
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.mk-lib/README.md
+++ b/.mk-lib/README.md
@@ -1,0 +1,95 @@
+# Docker compose makefile
+[![Build Status](https://travis-ci.org/krom/docker-compose-makefile.svg?branch=master)](https://travis-ci.org/krom/docker-compose-makefile)
+[![Release](https://img.shields.io/github/release/krom/docker-compose-makefile.svg)](https://github.com/krom/docker-compose-makefile/releases/latest)
+[![Commits since last release](https://img.shields.io/github/commits-since/krom/docker-compose-makefile/latest.svg)](https://github.com/krom/docker-compose-makefile/commits/master)
+[![Github All Releases](https://img.shields.io/github/downloads/krom/docker-compose-makefile/total.svg)](https://github.com/krom/docker-compose-makefile)
+[![GitHub issues](https://img.shields.io/github/issues/krom/docker-compose-makefile.svg)](https://github.com/krom/docker-compose-makefile/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/krom/docker-compose-makefile.svg)](https://github.com/krom/docker-compose-makefile/pulls)
+[![license](https://img.shields.io/github/license/krom/docker-compose-makefile.svg)](https://github.com/krom/docker-compose-makefile/blob/master/LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/krom/docker-compose-makefile.svg?style=social&label=Stars)](https://github.com/krom/docker-compose-makefile/stargazers)
+
+Template and lib for docker-compose
+
+## INSTALLATION
+### INSTALLATION
+To install mk-lib run command
+```bash
+curl -sL https://git.io/vh4Gn | sh
+```
+
+### UPGRADE
+To upgrade existing mk-lib run command
+```bash
+make mk-upgrade
+```
+
+## USAGE
+![Screen](https://raw.githubusercontent.com/krom/docker-compose-makefile/master/docs/screencast.gif)
+
+**Common** (see [samples](https://github.com/krom/docker-compose-makefile/tree/master/samples))
+- `make console` - open container's console
+
+**From Makefile.minimal.mk** (see [samples](https://github.com/krom/docker-compose-makefile/tree/master/samples))
+- `make start` - start all containers
+- `make start` c=hello** - start container hello
+- `make stop` - stop all containers
+- `make status` - show list of containers with statuses
+- `make clean` - clean all data
+
+**From this library**
+- `make help` - show help (see above)
+- `make mk-upgrade` - check for updates of mk-lib
+- `make mk-version` - show current version of mk-lib
+
+### VARIABLES
+* **ROOT_DIR** - full path to dir with *Makefile*
+* **MK_DIR** - fill path to *.mk-lib* dir
+* **DOCKER_COMPOSE** - docker-compose executable command
+* **DOCKER_COMPOSE_FILE** - docker-compose.yml file 
+
+## SAMPLES
+
+Basic commands (you can copy and paste it into your Makefile)
+
+```makefile
+up: ## Start all or c=<name> containers in foreground
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) up $(c)
+
+start: ## Start all or c=<name> containers in background
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) up -d $(c)
+
+stop: ## Stop all or c=<name> containers
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) stop $(c)
+
+status: ## Show status of containers
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) ps
+
+restart: ## Restart all or c=<name> containers
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) stop $(c)
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) up $(c) -d
+
+clean: confirm ## Clean all data
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) down
+```
+You may see samples [here](https://github.com/krom/docker-compose-makefile/tree/master/samples)
+
+## CUSTOMIZATION
+You can create _.make.env_ file in directory with Makefile or **current** directory
+
+Available variables
+
+* **DOCKER_COMPOSE** = {docker-compose executable command}
+* **DOCKER_COMPOSE_FILE** = {custom docker-compose.yml file}
+
+## TO-DO
+- check dependencies
+- update readme
+
+## CHANGELOG
+See [CHANGELOG](CHANGELOG.md)
+
+## LICENSE
+MIT (see [LICENSE](LICENSE))
+
+## AUTHOR
+[Roman Kudlay](http://roman.kudlay.pro) ([roman@kudlay.pro](mailto:roman@kudlay.pro))

--- a/.mk-lib/common.mk
+++ b/.mk-lib/common.mk
@@ -1,0 +1,25 @@
+MK_DIR := $(ROOT_DIR)/.mk-lib
+include $(MK_DIR)/variables.mk
+-include $(MK_DIR)/version.mk
+-include $(ROOT_DIR)/.make.env
+-include .make.env
+
+f ?= $(DOCKER_COMPOSE_FILE)
+DOCKER_COMPOSE_FILE := $(f)
+
+.DEFAULT_GOAL := help
+
+help: ##@other Show this help.
+	@perl -e '$(HELP_FUN)' $(MAKEFILE_LIST)
+
+confirm:
+	@( read -p "$(RED)Are you sure? [y/N]$(RESET): " sure && case "$$sure" in [yY]) true;; *) false;; esac )
+
+mk-upgrade: ##@other Check for updates of mk-lib
+	@MK_VERSION=$(MK_VERSION) MK_REPO=$(MK_REPO) $(MK_DIR)/self-upgrade.sh
+
+mk-version: ##@other Show current version of mk-lib
+	@echo $(MK_VERSION)
+
+check-dependencies:
+	@echo Checking dependencies

--- a/.mk-lib/self-upgrade.sh
+++ b/.mk-lib/self-upgrade.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+# Get some property from release
+# Usage:
+#   get_latest_release user/repo tag_name
+get_latest_release() {
+  curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
+    grep "\"$2\":" |                                                # Get tag line
+    sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
+}
+
+# Getting last version
+NEW_VER=$(get_latest_release $MK_REPO tag_name)
+
+if [ $NEW_VER = $MK_VERSION ]; then
+    echo 'Up to date';
+else
+    echo "A new version is available"
+    body=$(get_latest_release $MK_REPO body)
+    echo "Upgrading from $MK_VERSION to $NEW_VER
+
+     Release notes
+************************
+$body
+************************
+";
+    # Downloading and executing upgrade script
+    curl -sL https://raw.githubusercontent.com/$MK_REPO/master/scripts/upgrade.sh | ( echo "MK_REPO=$MK_REPO; MK_VERSION=$NEW_VER; "; cat -   ) | sh
+fi;

--- a/.mk-lib/variables.mk
+++ b/.mk-lib/variables.mk
@@ -1,0 +1,26 @@
+#COLORS
+GREEN  := $(shell tput -Txterm setaf 2)
+WHITE  := $(shell tput -Txterm setaf 7)
+YELLOW := $(shell tput -Txterm setaf 3)
+RED := $(shell tput -Txterm setaf 1)
+RESET  := $(shell tput -Txterm sgr0)
+
+# Add the following 'help' target to your Makefile
+# And add help text after each target name starting with '\#\#'
+# A category can be added with @category
+HELP_FUN = \
+    %help; \
+    while(<>) { push @{$$help{$$2 // 'options'}}, [$$1, $$3] if /^([a-zA-Z\-]+)\s*:.*\#\#(?:@([a-zA-Z\-]+))?\s(.*)$$/ }; \
+    print "usage: make [target]\n\n"; \
+    for (sort keys %help) { \
+    print "${WHITE}$$_:${RESET}\n"; \
+    for (@{$$help{$$_}}) { \
+    $$sep = " " x (32 - length $$_->[0]); \
+    print "  ${YELLOW}$$_->[0]${RESET}$$sep${GREEN}$$_->[1]${RESET}\n"; \
+    }; \
+    print "\n"; }
+
+#DEFAULT variables
+DOCKER_COMPOSE := docker-compose
+DOCKER_COMPOSE_FILE := $(ROOT_DIR)/docker-compose.yml
+MK_REPO := krom/docker-compose-makefile

--- a/.mk-lib/version.mk
+++ b/.mk-lib/version.mk
@@ -1,0 +1,1 @@
+MK_VERSION := v1.0.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:12-alpine
+
+WORKDIR /home/node
+
+RUN apk add --no-cache libtool autoconf automake make gcc g++ libsodium libc6-compat python
+COPY --chown=node ./package* /home/node/
+
+RUN npm install && \
+    npm cache clean --force
+
+COPY --chown=node . /home/node/
+COPY --chown=node ./packages/dashboard/.env.example /home/node/packages/dashboard/.env
+
+RUN npm run bootstrap && npm run build
+
+RUN apk delete libtool autoconf automake make gcc g++ libsodium libc6-compat python
+
+USER node
+
+WORKDIR /home/node/packages/cli
+RUN /home/node/packages/cli/bin/run config:init
+CMD /home/node/packages/cli/bin/run start && /home/node/packages/cli/bin/run logs --live

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# REQUIRED SECTION
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+include $(ROOT_DIR)/.mk-lib/common.mk
+# END OF REQUIRED SECTION
+
+.PHONY: help dependencies up start stop build restart status ps clean
+
+dependencies: check-dependencies ## Check dependencies
+	which docker
+	which docker-compose
+
+up: ## Start all or c=<name> containers in foreground
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) up $(c)
+
+build: ## Start all or c=<name> containers in foreground
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) build $(c)
+
+start: ## Start all or c=<name> containers in background
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) up -d $(c)
+
+stop: ## Stop all or c=<name> containers
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) stop $(c)
+
+restart: ## Restart all or c=<name> containers
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) stop $(c)
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) up $(c) -d
+
+status: ## Show status of containers
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) ps
+
+ps: status ## Alias of status
+
+clean: confirm ## Clean all data
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.3'
+services:
+  proxy:
+    image: traefik:v2.2
+    command: --api.insecure=true --providers.docker --log=false
+    labels:
+      traefik.http.routers.proxy.rule: "Host(`proxy.local`)"
+      traefik.http.services.proxy.loadbalancer.server.port: "8080"
+      traefik.docker.network: traefik
+    restart: on-failure
+    ports:
+      - '80:80'
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  seeder:
+    build:
+      context: ./
+    image: geut/permanent-seeder
+    labels:
+      traefik.http.routers.seeder.rule: "Host(`localhost`)"
+      traefik.http.services.seeder.loadbalancer.server.port: "3001"


### PR DESCRIPTION
#30 Using as a baseline this [helpers](https://github.com/krom/docker-compose-makefile), here is a Dockerfile and docker-compose to run **permanent-seeder**

So now running `make up` will leave the up running at http://localhost (please check that you don't have any running service on port 80)