### PR TITLE
Use api config to open dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - packages/seeder
   - Fix: use corestoreOpts + allow optional preferredPort setting
 - Docs update
+
+### Fixed
+- packages/cli
+  - Use api config to open dashboard in browser

--- a/packages/cli/src/commands/dashboard.js
+++ b/packages/cli/src/commands/dashboard.js
@@ -3,10 +3,16 @@ const { cli } = require('cli-ux')
 
 class DashboardCommand extends BaseCommand {
   async run () {
+    const config = this.checkConfig()
+
+    const { api: { https, port = 3001 } = {} } = config
+
+    const url = `http${https ? 's' : ''}://localhost:${port}/`
+
     try {
-      await cli.open('http://localhost:3001/')
+      await cli.open(url)
     } catch (_) {
-      this.log('Dashboard running in: http://localhost:3001')
+      this.log(`Dashboard running in: ${url}`)
     }
   }
 }


### PR DESCRIPTION
- Use `https` `port` from `api` config to open dashboard