### PR TITLE
Update: use preload for api/drives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - packages/dashboard
   - Expose public/index.html as main + assets tweaks
+  - Update: use preload for api/drives
 - packages/sdk
   - Use require.resolve with dirname to obtain the dasboard assets dir
   - Update: pass optional swarm port to seeder

--- a/packages/dashboard/public/index.html
+++ b/packages/dashboard/public/index.html
@@ -15,6 +15,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="preload" href="/api/drives" as="fetch" >
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/packages/dashboard/src/components/DriveItem.js
+++ b/packages/dashboard/src/components/DriveItem.js
@@ -70,7 +70,7 @@ function DriveItem ({ driveKey }) {
   const [showInfo, setShowInfo] = useState(false)
   const [showDetails, setShowDetails] = useState(false)
 
-  const { get, response, error } = useFetch(API_URL)
+  const { get, response, error } = useFetch(API_URL, { credentials: 'same-origin', mode: 'cors' })
 
   const { socket } = useSocket()
 

--- a/packages/seeder/src/drive.js
+++ b/packages/seeder/src/drive.js
@@ -139,7 +139,7 @@ class Drive extends EventEmitter {
   }
 
   async getStat (path = '/') {
-    return this._hyperdrive.stat(path)
+    return timeout(this._hyperdrive.stat(path), 200)
   }
 
   async getStats (path = '/', opts) {


### PR DESCRIPTION
This PR makes use of `link rel="preload"` option to do a quick first fetch of the `api/drives` endpoint.