### PR TITLE
Update: api raw up to date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Pino as default logger
 - packages/seeder
   - Fix: use corestoreOpts + allow optional preferredPort setting
+  - Update: add new drive-download-resume event, avoid emitting drive-add multiple times on restart
 - packages/metrics
   - Update: use trammel to get directory size of ps work dir
+  - Update: update to reflect latest events (drive life cycle)
 - Docs update
 
 ### Fixed

--- a/packages/dashboard/src/components/DriveFiles.js
+++ b/packages/dashboard/src/components/DriveFiles.js
@@ -19,6 +19,9 @@ const useStyles = makeStyles(theme => ({
     width: '100%',
     tableLayout: 'fixed'
   },
+  cell: {
+    overflowY: 'hidden'
+  },
   row: {
     '& > td, & > th': {
       padding: '6px 8px 6px 8px'
@@ -57,7 +60,7 @@ function DriveFiles ({ files, blocks, bytes }) {
           </TableRow>
           {Object.entries(files).map(([fileName, { size, blocks }]) => (
             <TableRow key={fileName} className={classes.row}>
-              <TableCell size='small'>{fileName}</TableCell>
+              <TableCell className={classes.cell} size='small'>{fileName}</TableCell>
               <TableCell align='right'>{humanizedBytes(size).pretty}</TableCell>
               <TableCell align='right'>{blocks}</TableCell>
             </TableRow>

--- a/packages/dashboard/src/components/DriveList.js
+++ b/packages/dashboard/src/components/DriveList.js
@@ -33,6 +33,7 @@ function buildDriveData (drive) {
     fsBlocks: fsSize.blocks,
     fsBytes: fsSize.bytes,
     info: drive.info,
+    recentlyAdded: drive.recentlyAdded,
     seedingStatus: drive.seedingStatus
   }
 }

--- a/packages/dashboard/src/components/DrivesTable.js
+++ b/packages/dashboard/src/components/DrivesTable.js
@@ -121,6 +121,7 @@ function DrivesTable ({ drives, onKeyAdd }) {
               fsBlocks={drive.fsBlocks}
               fsBytes={drive.fsBytes}
               info={drive.info}
+              recentlyAdded={drive.recentlyAdded}
               seedingStatus={drive.seedingStatus}
             />
           ))}

--- a/packages/dashboard/src/components/DrivesTableHead.js
+++ b/packages/dashboard/src/components/DrivesTableHead.js
@@ -10,6 +10,7 @@ import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline'
 import { makeStyles } from '@material-ui/core'
 
 const headCells = [
+  { id: 'newItem', numeric: false },
   { id: 'seedingStatus', numeric: false, label: 'Status', width: '40px' },
   {
     id: 'key',

--- a/packages/dashboard/src/components/DrivesTableRow.js
+++ b/packages/dashboard/src/components/DrivesTableRow.js
@@ -3,6 +3,7 @@ import { CopyToClipboard } from 'react-copy-to-clipboard'
 import fastDeepEqual from 'fast-deep-equal'
 
 import { makeStyles } from '@material-ui/core'
+import FiberNewOutlinedIcon from '@material-ui/icons/FiberNewOutlined'
 import TableCell from '@material-ui/core/TableCell'
 import MuiTableRow from '@material-ui/core/TableRow'
 import IconButton from '@material-ui/core/IconButton'
@@ -34,7 +35,11 @@ const useStyles = makeStyles((theme) => ({
   },
   key: {
     cursor: 'pointer'
+  },
+  newItem: {
+    width: '10px'
   }
+
 }))
 
 const DrivesTableRow = React.memo(
@@ -51,11 +56,13 @@ const DrivesTableRow = React.memo(
     fsBytes,
     info,
     seedingStatus,
+    recentlyAdded,
     onClick
   }) {
     const classes = useStyles()
     const [open, setOpen] = useState(false)
     const [detailsOpen, setDetailsOpen] = useState(false)
+    const [sawRecentlyAdded, setSawRecentlyAdded] = useState(recentlyAdded)
 
     function handleToggleInfo (event) {
       event.stopPropagation()
@@ -65,6 +72,12 @@ const DrivesTableRow = React.memo(
     function handleOpenDetails (event) {
       event.stopPropagation()
       setDetailsOpen(true)
+    }
+
+    function sawNewItem (event) {
+      event.stopPropagation()
+      // mark as seen
+      setSawRecentlyAdded(false)
     }
 
     return (
@@ -77,6 +90,15 @@ const DrivesTableRow = React.memo(
           onClick={handleOpenDetails}
           className={classes.root}
         >
+          <TableCell className={classes.newItem} padding='none' align='center'>
+            {sawRecentlyAdded
+              ? (
+                <IconButton size='small' onClick={sawNewItem}>
+                  <FiberNewOutlinedIcon />
+                </IconButton>
+              )
+              : ''}
+          </TableCell>
           <TableCell padding='none' align='center'>
             <IconButton aria-label='expand row' size='small' onClick={handleToggleInfo}>
               {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
@@ -97,7 +119,9 @@ const DrivesTableRow = React.memo(
               </CopyToClipboard>
             </div>
           </TableCell>
-          <TableCell>{title}</TableCell>
+          <TableCell>
+            {title}
+          </TableCell>
           <TableCell align='center'>{sizeBlocks}</TableCell>
           <TableCell align='center'>{humanizedBytes(sizeBytes).pretty}</TableCell>
           <TableCell align='center'>{downloadedBlocks}</TableCell>
@@ -105,7 +129,7 @@ const DrivesTableRow = React.memo(
           <TableCell align='center'>{peers.length}</TableCell>
         </MuiTableRow>
         <MuiTableRow>
-          <TableCell className={classes.collapse} colSpan={9}>
+          <TableCell className={classes.collapse} colSpan={10}>
             <Collapse in={open} timeout='auto' unmountOnExit>
               <DriveInfo
                 peers={peers}

--- a/packages/dashboard/src/components/HostStats.js
+++ b/packages/dashboard/src/components/HostStats.js
@@ -11,6 +11,7 @@ import CircularProgress from './CircularProgress'
 
 import { API_URL } from '../config'
 import { useMilisecondsToHms } from '../hooks/unit'
+import { humanizedBytes } from '../format'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -35,7 +36,7 @@ function Uptime ({ uptime }) {
 const DiskData = ({ disk = { directory: 0 } }) => {
   return (
     <Typography style={{ verticalAlign: 'center' }} variant='h6' component='div' color='textSecondary' gutterBottom>
-      {disk.directory}
+      {humanizedBytes(disk.directory).pretty}
     </Typography>
   )
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -47,7 +47,7 @@
     "pino": "^6.7.0",
     "process-top": "^1.1.0",
     "socket.io": "^2.3.0",
-    "trammel": "^4.0.0"
+    "nodejs-fs-utils": "^1.2.5"
   },
   "devDependencies": {
     "@geut/chan": "^2.0.0",

--- a/packages/sdk/src/services/keys-updater.service.js
+++ b/packages/sdk/src/services/keys-updater.service.js
@@ -19,10 +19,10 @@ module.exports = {
 
   events: {
     async 'keys.created' (ctx) {
-      await ctx.call('seeder.seed', { keys: ctx.params.keys.map(({ key }) => key) })
+      await ctx.call('seeder.seed', { keys: ctx.params.keys.map(({ key }) => key), created: true })
     },
     async 'keys.updated' (ctx) {
-      await ctx.call('seeder.seed', { keys: ctx.params.keys.map(({ key }) => key) })
+      await ctx.call('seeder.seed', { keys: ctx.params.keys.map(({ key }) => key), created: false })
     }
   },
 

--- a/packages/sdk/src/services/metrics.service.js
+++ b/packages/sdk/src/services/metrics.service.js
@@ -22,11 +22,10 @@ module.exports = {
 
   events: {
     'seeder.drive.*': {
-      throttle: 200,
       async handler (ctx) {
         const timestamp = Date.now()
-        const { eventName: event, params: { key } } = ctx
-        await this.saveStats({ key, timestamp, event })
+        const { eventName: event, params: { key, ...rest } } = ctx
+        await this.saveStats({ key, timestamp, event, ...rest })
       }
     },
     'seeder.networker.peer.*': {
@@ -108,8 +107,10 @@ module.exports = {
           return
         }
 
-        data.host = await this.getHostStats()
-        if (data.event !== 'seeder.drive.remove') {
+        if (data.event === 'seeder.drive.download-started' || data.event === 'seeder.drive.download-finished') {
+          data.host = await this.getHostStats()
+        }
+        if (data.event !== 'seeder.drive.download' && data.event !== 'seeder.drive.remove') {
           data.peers = await this.broker.call('seeder.drivePeers', { key: data.key })
         }
         return this.database.add(data)

--- a/packages/sdk/src/services/metrics.service.js
+++ b/packages/sdk/src/services/metrics.service.js
@@ -1,14 +1,15 @@
 const { resolve } = require('path')
+const { promisify } = require('util')
 
 const { MetricsDatabase } = require('@geut/permanent-seeder-database')
 const top = require('process-top')()
-const trammel = require('trammel')
+const { fsize } = require('nodejs-fs-utils')
 const pMemoize = require('p-memoize')
 const isOnline = require('is-online')
 
 const { Config } = require('../mixins/config.mixin')
 
-const dirSize = pMemoize(trammel, { maxAge: 2000 })
+const dirSize = pMemoize(promisify(fsize), { maxAge: 2000 })
 
 module.exports = {
   name: 'metrics',
@@ -73,7 +74,7 @@ module.exports = {
         let disk = ''
 
         try {
-          disk = await dirSize(this.config.path, { stopOnError: true })
+          disk = await dirSize(this.config.path, { skipErrors: true })
         } catch (error) {
           console.error(error)
         }

--- a/packages/sdk/src/services/seeder.service.js
+++ b/packages/sdk/src/services/seeder.service.js
@@ -20,10 +20,12 @@ module.exports = {
   actions: {
     seed: {
       params: {
-        keys: { type: 'array', min: 1 }
+        keys: { type: 'array', min: 1 },
+        created: { type: 'boolean', optional: true, default: false }
       },
       async handler (ctx) {
-        return this.seed(ctx.params.keys)
+        this.logger.info({ created: ctx.params.created }, 'seeder actions created?')
+        return this.seed(ctx.params.keys, ctx.params.created)
       }
     },
 
@@ -53,7 +55,7 @@ module.exports = {
   },
 
   methods: {
-    async seed (keys) {
+    async seed (keys, created) {
       const keysToSeed = []
 
       for (let key of keys) {
@@ -72,7 +74,7 @@ module.exports = {
         }
       }
 
-      return this.seeder.seed(keysToSeed)
+      return this.seeder.seed(keysToSeed, created)
     },
 
     async unseed (key) {

--- a/packages/sdk/src/services/seeder.service.js
+++ b/packages/sdk/src/services/seeder.service.js
@@ -116,6 +116,12 @@ module.exports = {
       this.broker.broadcast('seeder.drive.download.resume', { key, size })
     },
 
+    async onDriveDownloadFix (key, { size }) {
+      await this.database.update(key, {
+        size
+      })
+    },
+
     async onDriveDownload (key, { size, seedingStatus, started = false, finished = false }) {
       await this.database.update(key, {
         size,
@@ -183,6 +189,7 @@ module.exports = {
     this.seeder.on('drive-add', this.onDriveAdd)
     this.seeder.on('drive-download', this.onDriveDownload)
     this.seeder.on('drive-download-resume', this.onDriveDownloadResume)
+    this.seeder.on('drive-download-fix', this.onDriveDownloadFix)
     this.seeder.on('drive-info', this.onDriveInfo)
     this.seeder.on('drive-peer-add', this.onDrivePeerAdd)
     this.seeder.on('drive-peer-remove', this.onDrivePeerRemove)
@@ -201,6 +208,7 @@ module.exports = {
     this.seeder.off('drive-add', this.onDriveAdd)
     this.seeder.off('drive-download', this.onDriveDownload)
     this.seeder.off('drive-download-resume', this.onDriveDownloadResume)
+    this.seeder.off('drive-download-fix', this.onDriveDownloadFix)
     this.seeder.off('drive-info', this.onDriveInfo)
     this.seeder.off('drive-peer-add', this.onDrivePeerAdd)
     this.seeder.off('drive-peer-remove', this.onDrivePeerRemove)

--- a/packages/seeder/src/drive-events.md
+++ b/packages/seeder/src/drive-events.md
@@ -3,6 +3,7 @@
 ### Description
 
 - `drive-add`: emitted once when the key is added to the Permanent Seeder
+- `drive-download-resume`: emitted if there is a difference between total feed blocks and downloaded
 - `drive-download`: emitted on feed download.
     - `started`: set to `true` when download starts
         - updates seeding status: `waiting` => `downloading`
@@ -35,6 +36,7 @@
 Events are ordered from the _beggining_, i.e.: when they are added to the permanent seeder, to _end_ or when they are downloaded completely.
 
 - `drive-add`
+- `drive-download-resume`
 - `drive-download`
 - `drive-download` [**started**] [once]
     - `drive-info` [after-started]

--- a/packages/seeder/src/drive.js
+++ b/packages/seeder/src/drive.js
@@ -50,7 +50,7 @@ class Drive extends EventEmitter {
     this._onUpdate = this._onUpdate.bind(this)
     this._onUpload = this._onUpload.bind(this)
 
-    this._loadStats = debounce(this._loadStats.bind(this), 1000, { maxWait: 1000 * 3, leading: true })
+    this._loadStats = debounce(this._loadStats.bind(this), 100, { maxWait: 100 * 3, leading: true })
 
     this._hyperdrive.on('update', this._onUpdate)
     this._hyperdrive.on('peer-add', this._onPeerAdd)

--- a/packages/seeder/src/drive.js
+++ b/packages/seeder/src/drive.js
@@ -112,7 +112,7 @@ class Drive extends EventEmitter {
     }
     const downloaded = this._downloadedBlocks
     const total = this.feedBlocks
-    if (downloaded <= total) {
+    if (downloaded < total) {
       if (this._contentFeed.downloaded() > this._downloadedBlocks) {
         this._downloadedBlocks = this._contentFeed.downloaded()
       }

--- a/packages/seeder/src/drive.js
+++ b/packages/seeder/src/drive.js
@@ -112,6 +112,7 @@ class Drive extends EventEmitter {
     }
     const downloaded = this._downloadedBlocks
     const total = this.feedBlocks
+
     if (downloaded < total) {
       if (this._contentFeed.downloaded() > this._downloadedBlocks) {
         this._downloadedBlocks = this._contentFeed.downloaded()
@@ -124,6 +125,13 @@ class Drive extends EventEmitter {
       this.emit('download-resume', this._key, {
         size: this.getSize(),
         seedingStatus: this.getSeedingStatus()
+      })
+    } else if (downloaded > total) {
+      // correct values
+      this._logger.info({ key: this._key }, 'Adjusting download values')
+      this._downloadedBlocks = this.feedBlocks
+      this.emit('download-fix', this._key, {
+        size: this.getSize()
       })
     }
   }

--- a/packages/seeder/src/seeder.js
+++ b/packages/seeder/src/seeder.js
@@ -69,6 +69,7 @@ class Seeder extends EventEmitter {
 
     this._onDriveDownload = this._onDriveDownload.bind(this)
     this._onDriveDownloadResume = this._onDriveDownloadResume.bind(this)
+    this._onDriveDownloadFix = this._onDriveDownloadFix.bind(this)
     this._onDriveInfo = this._onDriveInfo.bind(this)
     this._onDrivePeerAdd = this._onDrivePeerAdd.bind(this)
     this._onDrivePeerRemove = this._onDrivePeerRemove.bind(this)
@@ -100,6 +101,10 @@ class Seeder extends EventEmitter {
     this.emit('drive-download-resume', key, data)
   }
 
+  _onDriveDownloadFix (key, data) {
+    this.emit('drive-download-fix', key, data)
+  }
+
   _onDriveInfo (key, data) {
     this.emit('drive-info', key, data)
   }
@@ -127,6 +132,7 @@ class Seeder extends EventEmitter {
   _registerDriveEvents (key, drive) {
     drive.on('download', this._onDriveDownload)
     drive.on('download-resume', this._onDriveDownloadResume)
+    drive.on('download-fix', this._onDriveDownloadFix)
     drive.on('info', this._onDriveInfo)
     drive.on('peer-add', this._onDrivePeerAdd)
     drive.on('peer-remove', this._onDrivePeerRemove)
@@ -136,6 +142,8 @@ class Seeder extends EventEmitter {
 
     this._unlistens.set(key, () => {
       drive.off('download', this._onDriveDownload)
+      drive.off('download-resume', this._onDriveDownloadResume)
+      drive.off('download-fix', this._onDriveDownloadFix)
       drive.off('info', this._onDriveInfo)
       drive.off('peer-add', this._onDrivePeerAdd)
       drive.off('peer-remove', this._onDrivePeerRemove)

--- a/packages/seeder/src/seeder.js
+++ b/packages/seeder/src/seeder.js
@@ -68,6 +68,7 @@ class Seeder extends EventEmitter {
     this._logger = this._opts.logger || console
 
     this._onDriveDownload = this._onDriveDownload.bind(this)
+    this._onDriveDownloadResume = this._onDriveDownloadResume.bind(this)
     this._onDriveInfo = this._onDriveInfo.bind(this)
     this._onDrivePeerAdd = this._onDrivePeerAdd.bind(this)
     this._onDrivePeerRemove = this._onDrivePeerRemove.bind(this)
@@ -153,7 +154,7 @@ class Seeder extends EventEmitter {
    * @param {number} keyRecord.size.downloadedBlocks downloaded blocks
    * @param {number} keyRecord.size.downloadedBytes downloaded bytes
    */
-  async _seedKey ({ key, size }) {
+  async _seedKey ({ key, size }, created = false) {
     // Check if drive was already seeded (in-mem)
     let drive = this._drives.get(key)
 
@@ -175,7 +176,9 @@ class Seeder extends EventEmitter {
     this._registerDriveEvents(key, drive)
 
     // Notify new drive
-    this.emit('drive-add', key)
+    if (size.blocks === 0 && created) {
+      this.emit('drive-add', key)
+    }
 
     // Connect to network
     await this._networker.configure(
@@ -248,11 +251,11 @@ class Seeder extends EventEmitter {
    *
    * @param {} keys
    */
-  async seed (keys = []) {
+  async seed (keys = [], created) {
     await this.init()
 
     for (const key of keys) {
-      this._seedKey(key).catch(error => this._logger.error({ key, error }, `Seeding error: ${error.message}`))
+      this._seedKey(key, created).catch(error => this._logger.error({ key, error }, `Seeding error: ${error.message}`))
     }
   }
 

--- a/packages/seeder/src/seeder.js
+++ b/packages/seeder/src/seeder.js
@@ -24,6 +24,7 @@ const DEFAULT_OPTS = {
   storageLocation: join(homedir(), 'permanent-seeder', '.hyper'),
   corestoreOpts: {
     sparse: false,
+    sparseMetadata: false,
     cache: {
       data: new HypercoreCache({
         maxByteSize: DATA_CACHE_SIZE,
@@ -33,8 +34,7 @@ const DEFAULT_OPTS = {
         maxByteSize: TREE_CACHE_SIZE,
         estimateSize: val => 40
       })
-    },
-    ifAvailable: true
+    }
   }
 }
 
@@ -63,7 +63,7 @@ class Seeder extends EventEmitter {
     super()
     this._opts = { ...DEFAULT_OPTS, ...opts }
     this._drives = new Map()
-    this._unlistens = []
+    this._unlistens = new Map()
     this._ready = false
     this._logger = this._opts.logger || console
 
@@ -95,6 +95,10 @@ class Seeder extends EventEmitter {
     this.emit('drive-download', key, data)
   }
 
+  _onDriveDownloadResume (key, data) {
+    this.emit('drive-download-resume', key, data)
+  }
+
   _onDriveInfo (key, data) {
     this.emit('drive-info', key, data)
   }
@@ -119,8 +123,9 @@ class Seeder extends EventEmitter {
     this.emit('drive-upload', key)
   }
 
-  _registerDriveEvents (drive) {
+  _registerDriveEvents (key, drive) {
     drive.on('download', this._onDriveDownload)
+    drive.on('download-resume', this._onDriveDownloadResume)
     drive.on('info', this._onDriveInfo)
     drive.on('peer-add', this._onDrivePeerAdd)
     drive.on('peer-remove', this._onDrivePeerRemove)
@@ -128,7 +133,7 @@ class Seeder extends EventEmitter {
     drive.on('update', this._onDriveUpdate)
     drive.on('upload', this._onDriveUpload)
 
-    this._unlistens.push(() => {
+    this._unlistens.set(key, () => {
       drive.off('download', this._onDriveDownload)
       drive.off('info', this._onDriveInfo)
       drive.off('peer-add', this._onDrivePeerAdd)
@@ -149,7 +154,7 @@ class Seeder extends EventEmitter {
    * @param {number} keyRecord.size.downloadedBytes downloaded bytes
    */
   async _seedKey ({ key, size }) {
-    // Check if drive present
+    // Check if drive was already seeded (in-mem)
     let drive = this._drives.get(key)
 
     // Already downloading
@@ -166,11 +171,8 @@ class Seeder extends EventEmitter {
     // Wait for readyness
     await drive.ready()
 
-    // Force download
-    drive.download()
-
     // Register event listeners
-    this._registerDriveEvents(drive)
+    this._registerDriveEvents(key, drive)
 
     // Notify new drive
     this.emit('drive-add', key)
@@ -181,8 +183,12 @@ class Seeder extends EventEmitter {
       { announce: this._opts.announce, lookup: this._opts.lookup }
     )
 
+    drive.download('/')
     // Wait for content ready
     await drive.getContentFeed()
+
+    // Resume Download
+    drive.resume()
   }
 
   /**
@@ -229,7 +235,7 @@ class Seeder extends EventEmitter {
 
     this._networker.on('peer-add', onPeerAdd)
     this._networker.on('peer-remove', onPeerRemove)
-    this._unlistens.push(() => {
+    this._unlistens.set('init', () => {
       this._networker.off('peer-add', onPeerAdd)
       this._networker.off('peer-remove', onPeerRemove)
     })
@@ -245,7 +251,9 @@ class Seeder extends EventEmitter {
   async seed (keys = []) {
     await this.init()
 
-    await Promise.all(keys.map(this._seedKey.bind(this)))
+    for (const key of keys) {
+      this._seedKey(key).catch(error => this._logger.error({ key, error }, `Seeding error: ${error.message}`))
+    }
   }
 
   drivePeers (key) {
@@ -308,6 +316,13 @@ class Seeder extends EventEmitter {
       discoveryKeys = this._drives.values().map(drive => drive.discoveryKey)
     }
 
+    if (this._unlistens.has(key)) {
+      const unlisten = this._unlistens.get(key)
+      // remove listeners attached to this key/drive
+      unlisten()
+      this._unlistens.delete(key)
+    }
+
     await Promise.all(discoveryKeys.map(discoveryKey => this._networker.configure(discoveryKey, { announce: false, lookup: false })))
 
     this._drives.delete(key)
@@ -319,11 +334,11 @@ class Seeder extends EventEmitter {
    * destroy.
    */
   async destroy () {
-    for (const unlisten of this._unlistens) {
+    for (const unlisten of this._unlistens.values()) {
       unlisten()
     }
 
-    this._unlistens = []
+    this._unlistens.clear()
 
     // close all drives
     try {


### PR DESCRIPTION
This PR adds:
- update `api/raw` with the latest event changes. Ideally now, if you query `api/raw/:key` you will see the life cycle of that hyperdrive being seeded. In addition we added an internal document with those events. See [here](packages/seeder/src/drive-events.md)
- add `resume` download function to the seeder. 
-  UI tweaks for `new` recently added keys.