### PR TITLE
fix: delete destroy storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- packages/seeder
+  - Update: unseed improvements (destroyStorage, closing)
 
 ## 1.0.0 - 2020-10-30
 ### Added

--- a/packages/cli/src/commands/key/remove-all.js
+++ b/packages/cli/src/commands/key/remove-all.js
@@ -9,20 +9,18 @@ const BaseCommand = require('../../base-command')
 class RemoveCommand extends KeyCommand {
   async run () {
     if (await cli.confirm('Are you sure?')) {
-      if (await cli.confirm('Really?')) {
-        const keys = await this.keysDatabase.getAll()
+      const keys = await this.keysDatabase.getAll()
 
-        for await (const { key } of keys) {
-          await this.keysDatabase.remove(key)
-          try {
-            await sendMessage(SEEDER_DAEMON, MESSAGE_SEEDER_UNSEED, { key })
-          } catch (error) {
-            this.error(error.message)
-          }
+      for await (const { key } of keys) {
+        await this.keysDatabase.remove(key)
+        try {
+          await sendMessage(SEEDER_DAEMON, MESSAGE_SEEDER_UNSEED, { key })
+        } catch (error) {
+          this.error(error.message)
         }
-
-        this.log('Keys removed')
       }
+
+      this.log('Keys removed')
     }
 
     this.exit(0)

--- a/packages/cli/src/commands/start.js
+++ b/packages/cli/src/commands/start.js
@@ -59,7 +59,6 @@ class StartCommand extends BaseCommand {
         args,
         wait_ready: true,
         listen_timeout: 5000,
-        max_memory_restart: '1024M',
         force: true
       })
     } catch (error) {

--- a/packages/sdk/src/services/metrics.service.js
+++ b/packages/sdk/src/services/metrics.service.js
@@ -111,7 +111,7 @@ module.exports = {
         if (data.event === 'seeder.drive.download-started' || data.event === 'seeder.drive.download-finished') {
           data.host = await this.getHostStats()
         }
-        if (data.event !== 'seeder.drive.download' && data.event !== 'seeder.drive.remove') {
+        if (data.event !== 'seeder.drive.add' && data.event !== 'seeder.drive.download' && data.event !== 'seeder.drive.remove') {
           data.peers = await this.broker.call('seeder.drivePeers', { key: data.key })
         }
         return this.database.add(data)


### PR DESCRIPTION
This PR fixes a situation where `destroyStorage` was not called and ended up with an incomplete `unseed` operation.

 