### PR TITLE
Update: new release workflow pr and publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,17 @@
 name: Publish
 
 on:
-  release:
-    types: [published]
+  pull_request:
+    branches:
+      - master
+    types: [closed]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'Release:')
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 12
@@ -18,3 +21,15 @@ jobs:
       - run: npm run publish:ci
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - name: Set version
+        id: lerna-version
+        shell: bash -ex {0}
+        run: |
+          version=$(node -p 'require("./lerna.json").version')
+          echo "::set-output name=version::${version}"
+      - name: Tag commit
+        uses: tvdias/github-tagger@v0.0.1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "v${{ steps.lerna-version.outputs.version }}"
+      - run: npm run ghrelease:ci

--- a/README.md
+++ b/README.md
@@ -243,10 +243,13 @@ Returns the raw data that feed into the dashboard.
 
 ## Release
 
-For releasing we are using GitHub actions :rocket: This is a 2 step process:
-1. First, we need to create the new version. This new version will trigger a changelog update and prepare the new release using **GitHub Releases**.
-    - `npm run release`
-2. When the new GitHub Release is **published**, a custom action will be triggered uploading the new version to npm :new: :package:
+For releasing new versions we are using GitHub Actions :rocket: This is the process.
+
+1. First, we create a new **release** branch: `git co -b username/release-${newVersion}`
+2. Then, we need to create the new version. This new version will trigger a changelog update (using [chan](https://github.com/geut/chan)). To do this just run: `npm run release` It will prompt you what is the next version.
+3. Create the **release pull-request**. The title should indicate this: `Release: newVersion`
+    - :warning: This is an important step, otherwise the publish workflow won't see the PR.
+4. Finally, when the **release** PR is approved, a custom action will be triggered publishing the new version to npm, creating a new tag for it and creating a brand new github release :new: :package:
 
 ## <a name="issues"></a> Issues
 

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
     "test": "lerna run test",
     "posttest": "npm run lint",
     "lerna": "lerna",
-    "release": "lerna version",
-    "postversion": "chan release --allow-yanked --ghrelease $(node -p -e \"require('./lerna.json').version\") && git add CHANGELOG.md && git commit -m \"Update: changelog\"",
+    "release": "lerna version --no-git-tag-version",
+    "postversion": "chan release --allow-yanked && git add CHANGELOG.md && git commit -m \"Update: changelog\"",
     "publish": "lerna publish",
-    "publish:ci": "lerna publish from-git --yes"
+    "publish:ci": "lerna publish from-git --yes",
+    "ghrelease:ci": "chan gh-release $(node -p -e \"require('./lerna.json').version\")"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This PR introduces a new release workflow. It is pr-based. Steps are documented, but in short looks like this: 1, create a new release branch and do the version bump with the `npm run release` command. This will also update the changelog 2, with this new branch create the release pr: "Release: **newVersion**" 3. when the PR got merged, the publish workflow will run :rocket: