### PR TITLE
Update: doing commits and push from npm scripts :(

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "test": "lerna run test",
     "posttest": "npm run lint",
     "lerna": "lerna",
-    "release": "lerna version --no-git-tag-version",
-    "postversion": "chan release --allow-yanked && git add CHANGELOG.md && git commit -m \"Update: changelog\"",
+    "release": "lerna version --no-git-tag-version && git add . && git commit -m \"Update: version bump\" && npm run postrelease",
+    "postrelease": "chan release --allow-yanked && git add CHANGELOG.md && git commit -m \"Update: changelog\" && git push",
     "publish": "lerna publish",
     "publish:ci": "lerna publish from-git --yes",
     "ghrelease:ci": "chan gh-release $(node -p -e \"require('./lerna.json').version\")"


### PR DESCRIPTION
Using lerna version option `https://github.com/lerna/lerna/tree/main/commands/version#--no-git-tag-version` to avoid local tagging also skips commits and push, so we need to do that manually...