### PR TITLE
Fix: remove bad deps (hooks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- packages/dashboard
+  - Fix: remove unnecesary hook dependencies
 
 ## [1.0.2] - 2020-11-16
 ### Changed

--- a/packages/dashboard/src/components/DriveList.js
+++ b/packages/dashboard/src/components/DriveList.js
@@ -72,7 +72,8 @@ function DriveList ({ loadDrives, onKeyAdd }) {
       unsubscribeKeyUpdate()
       unsubscribeKeyRemove()
     }
-  }, [unsubscribeKeyUpdate, unsubscribeKeyRemove])
+    // eslint-disable-next-line
+  }, [])
 
   if (!drives) { return null }
 


### PR DESCRIPTION
There was one last bad dependency added that need to be removed. This is causing some issues with the dashboard.