### PR TITLE
Update: lock cron dep 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - packages/seeder
   - Update: get rid of connectivity method call #150
+- packages/sdk
+  - Fix: Using cron v1.7.2 #151
 
 ## [1.0.4] - 2020-11-17
 ### Changed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -36,7 +36,7 @@
     "@geut/permanent-seeder-dashboard": "^1.0.4",
     "@geut/permanent-seeder-database": "^1.0.0",
     "compression": "^1.7.4",
-    "cron": "^1.8.2",
+    "cron": "1.7.2",
     "deep-equal": "^2.0.4",
     "fromentries": "^1.2.1",
     "got": "^11.7.0",


### PR DESCRIPTION
We are locking `cron` dep to 1.7.2 due to this: https://github.com/kelektiv/node-cron/issues/478