### PR TITLE
Update: delete keys mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- packages/sdk
+  - Added: new delete endpoint #162
 
 ## [1.0.6] - 2021-03-06
 ### Changed

--- a/README.md
+++ b/README.md
@@ -244,6 +244,18 @@ To do this, you can tweak the hook response. By default the "delete keys endpoin
 
 Finally, the fetch frequency is managed by the keys endpoint frequency. In other words, they run with the same frequency interval.
 
+### Update Policy
+
+Here are some rules that we follow to know when to update the keys.
+
+Actions that result in update:
+- add endpoint is defined and returns a list of keys. delete endpoint is not defined. :white_check_mark:
+- add endpoint is defined and returns a list of keys. delete endpoint is defined and returns a list of keys. :white_check_mark:
+
+Actions that does not result in update:
+- add endpoint is defined and returns an empty list. Does not matter if delete endpoint is defined or not. :no_entry:
+- add endpoint is defined but throws an error :no_entry:
+- add endpoint is defined and returns a list of keys. delete endpoint is defined but throws an error. :no_entry:
 
 ## Secret
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,24 @@ frequency = 5
 hook = "$HOME/permanent-seeder/endpoint-hook.js"
 ```
 
+### Delete Keys Endpoint
+
+The Permanent Seeder also allows for another endpoint, this one for deleted keys. With this action the Permanent Seeder can fetch an array of keys similarly to what we defined previously for the keys endpoint (adding).
+
+The setting looks like this:
+```toml
+ [[keys.remove]]
+ url = "http://localhost:60620/deletes.json"
+ hook = "/Users/deka/permanent-seeder/endpoint-hook.js"
+```
+
+Again, we internally expect an `Array<{url}>`, but you can customize and parse the fetch response the way you need it.
+
+To do this, you can tweak the hook response. By default the "delete keys endpoint" is using the same default hook used with the keys endpoint.
+
+Finally, the fetch frequency is managed by the keys endpoint frequency. In other words, they run with the same frequency interval.
+
+
 ## Secret
 
 Sensitive information is hashed and salted. Check out your settings `secret` value in `~/permanent-seeder/settings.toml` to customize your salt value.

--- a/packages/cli/src/templates/settings.template.toml
+++ b/packages/cli/src/templates/settings.template.toml
@@ -28,8 +28,10 @@ save_stats = true
   # Hook to parse response
   hook = 'endpoint-hook.js'
 
-## [optional] To add another endpoint, uncomment and complete next lines:
-# [[keys.endpoints]]
-#   url =
-#   frequency =
-#   hook
+## [[keys.remove]]
+  # delete keys endpoint
+  # url = ''
+
+  # Hook to parse response
+  # hook = 'endpoint-hook.js'
+

--- a/packages/cli/src/templates/settings.template.toml
+++ b/packages/cli/src/templates/settings.template.toml
@@ -16,7 +16,7 @@ save_stats = true
 # cert = "/path/to/file.crt"
 # key = "/path/to/file.key"
 
-## keys.endpoints = array of configs per endpoint
+## keys.endpoints
 [[keys.endpoints]]
 
   # Where to fetch keys
@@ -28,6 +28,7 @@ save_stats = true
   # Hook to parse response
   hook = 'endpoint-hook.js'
 
+## [optional] remove keys endpoints
 ## [[keys.remove]]
   # delete keys endpoint
   # url = ''

--- a/packages/database/src/database.js
+++ b/packages/database/src/database.js
@@ -78,6 +78,10 @@ class Database {
     return this._filter(filter)
   }
 
+  async batch (keys = []) {
+    return this._db.batch(keys, { keyEncoding: this._buildKey })
+  }
+
   async remove (...keyParts) {
     return this._db.del(this._buildKey(keyParts))
   }

--- a/packages/database/src/database.js
+++ b/packages/database/src/database.js
@@ -79,7 +79,8 @@ class Database {
   }
 
   async batch (keys = []) {
-    return this._db.batch(keys, { keyEncoding: this._buildKey })
+    const buildKeys = keys.map(datum => ({ type: 'del', key: this._buildKey([datum.key]) }))
+    return this._db.batch(buildKeys)
   }
 
   async remove (...keyParts) {

--- a/packages/sdk/src/services/keys-updater.service.js
+++ b/packages/sdk/src/services/keys-updater.service.js
@@ -29,7 +29,7 @@ module.exports = {
       await ctx.call('seeder.seed', { keys: ctx.params.keys.map(({ key }) => key), created: true })
     },
     async 'keys.removed' (ctx) {
-      await ctx.call('seeder.unseed', { keys: ctx.params.keys.map(({ key }) => key) })
+      await ctx.call('seeder.unseedAll', { keys: ctx.params.keys.map(({ key }) => key) })
     }
   },
 

--- a/packages/sdk/src/services/keys-updater.service.js
+++ b/packages/sdk/src/services/keys-updater.service.js
@@ -27,8 +27,10 @@ module.exports = {
   events: {
     async 'keys.created' (ctx) {
       await ctx.call('seeder.seed', { keys: ctx.params.keys.map(({ key }) => key), created: true })
+    },
+    async 'keys.removed' (ctx) {
+      await ctx.call('seeder.unseed', { keys: ctx.params.keys.map(({ key }) => key) })
     }
-
   },
 
   actions: {
@@ -101,8 +103,10 @@ module.exports = {
       // keysToRemove = [{url:'C'}, {url: 'A'}]
       // keys = [{url:B}]
 
-      const keys = keysToAdd
       this.logger.info({ keysToRemove }, 'runUpdate: keysToRemove')
+      await this.broker.call('keys.remove', { keys: keysToRemove })
+
+      const keys = keysToAdd
       if (keysToRemove.length) {
         // get the diff
         for (const { url } of keysToRemove) {

--- a/packages/sdk/src/services/keys-updater.service.js
+++ b/packages/sdk/src/services/keys-updater.service.js
@@ -87,17 +87,19 @@ module.exports = {
           if (this.lastCall.add && (this.lastCall.add === keysToAddLength)) {
             // nothing changed, we can skip adding keys
             skipAdd = true
-          } else {
-            this.lastCall.add = keysToAddLength
           }
+          this.lastCall.add = keysToAddLength
         }
       } catch (error) {
+        this.logger.warn('Add endpoint failed. Cancelling keys update operation.')
         this.logger.warn(error)
+        return
       }
 
       if (remove.url) {
         try {
           keysToRemove = await fetchListOfKeys(remove.url, removeHook, { retry: 0, timeout: 5000 })
+          this.lastCall.remove = keysToRemove.length
         } catch (error) {
           this.logger.warn('Remove endpoint failed. Cancelling keys update operation.')
           this.logger.warn(error)
@@ -119,7 +121,7 @@ module.exports = {
 
       // keys = [{url:B}]
 
-      this.logger.info({ keysToRemove }, 'runUpdate: keysToRemove')
+      this.logger.info({ lastCall: this.lastCall }, 'runUpdate: this.lastCall updated')
       await this.broker.call('keys.remove', { keys: keysToRemove })
 
       if (skipAdd) {
@@ -149,7 +151,6 @@ module.exports = {
       add: 0,
       remove: 0
     }
-    this.logger.info('>>>>>> created keys-updater')
     // Note(dk): simplifying this step, we only admit 1 add endpoint
     // and 1 removal endpoint
 

--- a/packages/sdk/src/services/keys-updater.service.js
+++ b/packages/sdk/src/services/keys-updater.service.js
@@ -7,6 +7,13 @@ async function defaultHook (response) {
   return response.json()
 }
 
+async function fetchListOfKeys (url, hook, options = {}) {
+  const response = got(url, options)
+
+  const keys = await hook(response)
+  return keys
+}
+
 module.exports = {
   name: 'keys-updater',
 
@@ -21,75 +28,141 @@ module.exports = {
     async 'keys.created' (ctx) {
       await ctx.call('seeder.seed', { keys: ctx.params.keys.map(({ key }) => key), created: true })
     }
+
   },
 
   actions: {
     update: {
       async handler (ctx) {
-        const { endpoints } = this.settings.config.keys
-        for (const endpoint of endpoints) {
-          await this.runUpdate(endpoint)
-        }
+        const { endpoints, remove } = this.settings.config.keys
+        this.logger.info({ keys: this.settings.config.keys })
+        await this.runUpdate({ add: endpoints[0], remove: remove[0] })
       }
     }
   },
 
   methods: {
-    async runUpdate (endpoint) {
-      this.logger.info({ endpoint }, 'Running update key job for endpoint')
+    async runUpdate ({ add = {}, remove = {} }) {
+      if (!add.url && !remove.url) return
+
+      this.logger.info({ add, remove }, 'Running update key job for endpoint')
 
       let hook = defaultHook
+      let removeHook = defaultHook
 
-      if (endpoint.hook) {
+      // Note (dk): check if the user is using the delete keys settings. If so, get the
+      // delete endpoint if defined (if not, use default endpoint hook).
+
+      if (add.hook) {
         try {
-          hook = require(endpoint.hook)
+          hook = require(add.hook)
         } catch (error) {
           this.logger.error(error)
         }
       }
 
+      if (remove.hook) {
+        try {
+          removeHook = require(remove.hook)
+        } catch (error) {
+          this.logger.error(error)
+        }
+      }
+
+      let keysToAdd = []
+      let keysToRemove = []
       try {
-        const response = got(endpoint.url)
+        // Note(dk): if the user has enabled the delete keys endpoint and there is a url present
+        // in settings, then perform a second got call to this endpoint. Use the delete hook to parse.
 
-        const keys = await hook(response)
-
-        await this.broker.call('keys.updateAll', { keys })
+        keysToAdd = await fetchListOfKeys(add.url, hook, { retry: 0, timeout: 5000 })
       } catch (error) {
         this.logger.error(error)
       }
+
+      if (remove.url) {
+        try {
+          keysToRemove = await fetchListOfKeys(remove.url, removeHook, { retry: 0, timeout: 5000 })
+        } catch (error) {
+          this.logger.error(error)
+        }
+      }
+
+      if (!keysToAdd.length) {
+        this.logger.warn('Add keys endpoint returned an empty list. Omitting keys update step.')
+        return
+      }
+
+      // Note(dk): after getting both responses (from add and delete endpoints -last one is optional-)
+      // then we need to merge results. Removing keys from the output if they are present in the delete
+      // endpoint result.
+
+      // keysToAdd = [{url: 'A'}, {url: 'B'}]
+      // keysToRemove = [{url:'C'}, {url: 'A'}]
+      // keys = [{url:B}]
+
+      const keys = keysToAdd
+      this.logger.info({ keysToRemove }, 'runUpdate: keysToRemove')
+      if (keysToRemove.length) {
+        // get the diff
+        for (const { url } of keysToRemove) {
+          keys.splice(keys.findIndex(item => item.url === url), 1)
+        }
+      }
+
+      this.logger.info({ keys }, 'runUpdate: final keys')
+
+      await this.broker.call('keys.updateAll', { keys })
     }
   },
 
   created () {
-    const { endpoints } = this.settings.config.keys
+    const { endpoints, remove = [] } = this.settings.config.keys
 
-    this.crons = endpoints.map((endpoint, index) => {
-      const job = new cron.CronJob({
-        name: `update-keys-job-${index}`,
-        cronTime: `*/${endpoint.frequency} * * * *`,
-        onTick: () => {
-          this.runUpdate(endpoint)
-        }
-      })
+    this.endpoints = {}
+    this.logger.info('>>>>>> created keys-updater')
+    //   this.crons = endpoints.map((endpoint, index) => {
 
-      return {
-        ...endpoint,
-        job
+    // Note(dk): simplifying this step, we only admit 1 add endpoint
+    // and 1 removal endpoint
+
+    this.endpoints.add = endpoints[0] || {}
+    this.endpoints.remove = remove[0] || {}
+
+    this.logger.info({ addEndpoint: this.endpoints.add }, '>>>>>> created keys-updater')
+    this.logger.info({ removeEndpoint: this.endpoints.remove }, '>>>>>> created keys-updater')
+
+    // Note(dk) updates run at the same frequency at the moment
+    this.job = new cron.CronJob({
+      name: 'update-keys-job-add-remove',
+      cronTime: `*/${this.endpoints.add.frequency} * * * *`,
+      onTick: () => {
+        this.runUpdate({ add: this.endpoints.add, remove: this.endpoints.remove })
       }
     })
+
+    return {
+      add: this.endpoints.add,
+      remove: this.endpoints.remove,
+      job: this.job
+    }
+    //   })
   },
 
   started () {
-    this.crons.forEach(cron => {
-      cron.job.start()
-      this.logger.info({ url: cron.url }, 'Job for key update started')
-    })
+    this.logger.info('STARTING KEYS UPDATER...')
+    // this.crons.forEach(cron => {
+    this.job.start()
+    this.logger.info({ add: this.endpoints.add.url, remove: this.endpoints.remove.url }, 'Job for key update started')
+    this.logger.info('STARTED KEYS UPDATER OK')
+    // })
   },
 
   stopped () {
-    this.crons.forEach(cron => {
-      cron.job.stop()
-      this.logger.info({ url: cron.url }, 'Job for key update stopped')
-    })
+    this.logger.info('STOPPED KEYS UPDATER')
+    // this.crons.forEach(cron => {
+    this.job.stop()
+    this.logger.info({ add: this.endpoints.add.url, remove: this.endpoints.remove.url }, 'Job for key update stopped')
+    // })
   }
 }

--- a/packages/sdk/src/services/keys.service.js
+++ b/packages/sdk/src/services/keys.service.js
@@ -38,6 +38,28 @@ module.exports = {
       }
     },
 
+    remove: {
+      params: {
+        keys: {
+          type: 'array',
+          items: {
+            type: 'object',
+            props: {
+              url: { type: 'string' }
+            }
+          }
+        }
+      },
+      async handler (ctx) {
+        const keys = ctx.params.keys.map(datum => {
+          const key = encode(datum.url)
+
+          return { key, type: 'del' }
+        })
+        await this.removeKeys(keys)
+      }
+    },
+
     add: {
       params: {
         key: { type: 'string', length: '64', hex: true }
@@ -80,16 +102,22 @@ module.exports = {
       }
     },
 
+    async removeKeys (keys) {
+      await this.database.batch(keys)
+      if (keys.length) {
+        this.broker.broadcast('keys.removed', { keys })
+      }
+    },
+
     async updateKeys (keys) {
       const updateResult = await Promise.all(keys.map(keyRecord => this.update(keyRecord)))
 
-      // const updated = updateResult.filter(({ updated }) => updated).map(({ keyRecord }) => keyRecord)
       const created = updateResult.filter(({ created }) => created).map(({ keyRecord }) => keyRecord)
 
       if (created.length) {
         this.broker.cacher.clean()
       }
-      // updated.length && this.broker.broadcast('keys.updated', { keys: updated })
+
       created.length && this.broker.broadcast('keys.created', { keys: created })
     }
   },

--- a/packages/sdk/src/services/keys.service.js
+++ b/packages/sdk/src/services/keys.service.js
@@ -54,8 +54,9 @@ module.exports = {
         const keys = ctx.params.keys.map(datum => {
           const key = encode(datum.url)
 
-          return { key, type: 'del' }
+          return { key }
         })
+        this.logger.info('keys service: remove handler')
         await this.removeKeys(keys)
       }
     },
@@ -103,6 +104,7 @@ module.exports = {
     },
 
     async removeKeys (keys) {
+      this.logger.info({ keys }, 'keys service: removeKeys method ')
       await this.database.batch(keys)
       if (keys.length) {
         this.broker.broadcast('keys.removed', { keys })

--- a/packages/sdk/src/services/seeder.service.js
+++ b/packages/sdk/src/services/seeder.service.js
@@ -38,6 +38,17 @@ module.exports = {
       }
     },
 
+    unseedAll: {
+      params: {
+        keys: { type: 'array' }
+      },
+      async handler (ctx) {
+        for (const key of ctx.params.keys) {
+          await this.unseed(key)
+        }
+      }
+    },
+
     drivePeers: {
       params: {
         key: { type: 'string', length: '64', hex: true }


### PR DESCRIPTION
This PR introduces a new setting option, to allow a `delete keys` endpoint. If it is defined, it is expected to return a list of keys in a similar fashion than the current keys endpoints mechanism. 

Closes #155 