### PR TITLE
Update: add no verify access option as a workaround for lerna publish…

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lerna": "lerna",
     "release": "lerna version --no-git-tag-version && git add . && git commit -m \"Update: version bump\" && npm run release:chan",
     "release:chan": "chan release --allow-yanked $(node -p -e \"require('./lerna.json').version\") && git add CHANGELOG.md && git commit -m \"Update: changelog\" && git push origin HEAD",
-    "publish:ci": "lerna publish from-package --yes",
+    "publish:ci": "lerna publish from-package --no-verify-access --yes",
     "ghrelease:ci": "chan gh-release $(node -p -e \"require('./lerna.json').version\")"
   },
   "husky": {


### PR DESCRIPTION
Adds `no-verify-access` option as a workaround for lerna publish from ci.

Related to https://github.com/lerna/lerna/issues/2788